### PR TITLE
cleaned up stems and affixes data

### DIFF
--- a/data/affixes.txt
+++ b/data/affixes.txt
@@ -24,137 +24,137 @@ lp:::y'ɛ=:::'ye=:::'horse, colt' :::http://www.archive.org/stream/rosettaprojec
 ls:::=alp:::=alp:::'feeling' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n625/mode/2up:::page 612 (479)
 ls:::=alpqʷ:::=alpqw:::'mouth inside, oral cavity' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n629/mode/2up:::page 616 (499)
 ls:::=alqʷ:::=alqw:::'log, stick like object, tree' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n629/mode/2up:::page 616 (498)
-ls:::=alq:::=alq:::variant of =alqʷ:::variant:::variant
+ls:::=alq:::=alq:::variant of =alqʷ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n629/mode/2up:::variant
 ls:::=al'qs:::=a'lqs:::'clothes' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n624/mode/2up:::page 611 (471)
 ls:::=alqs:::=alqs:::'end' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n624/mode/2up:::page 611 (477)
 ls:::=alqs:::=alqs:::'road' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n631/mode/2up:::page 618 (509)
 ls:::=alq-šən:::=alq-shn:::'used for long bones of the leg' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n638/mode/2up:::page 625 (552)
 ls:::=aɫ-g'iw't:::=aɫ-g'i'wt:::'shoulder, part from neck to edge of shoulder' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n631/mode/2up:::page 618 (511)
 ls:::=aɫqixʷ:::=aɫqikhw:::'breath' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n623/mode/2up:::page 610 (468)
-ls:::=ɫqixʷ:::=ɫqikhw:::variant of =aɫqixʷ:::variant:::variant
+ls:::=ɫqixʷ:::=ɫqikhw:::variant of =aɫqixʷ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n623/mode/2up:::variant
 ls:::=ap-al'qs:::=ap-a'lqs:::'bottom clothes' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n637/mode/2up:::page 624 (547)
 ls:::=aqs:::=aqs:::'breast' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n623/mode/2up:::page 610 (467)
 ls:::=asq'it:::=asq'it:::'day, sky, atmosphere' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n624/mode/2up:::page 611 (472)
-ls:::=sq'it:::=sq'it:::variant of =asq'it:::variant:::variant
+ls:::=sq'it:::=sq'it:::variant of =asq'it:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n624/mode/2up:::variant
 ls:::=astq:::=astq:::'in opposition to' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n637/mode/2up:::page 624 (542)
-ls:::=stq:::=stq:::variant of =astq:::variant:::variant
+ls:::=stq:::=stq:::variant of =astq:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n637/mode/2up:::variant
 ls:::=aw'as-qən:::=a'was-qn:::'corner, angle, in hair, on top of head' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n638/mode/2up:::page 625 (550)
 ls:::=ax̣ən:::=aqhn:::'arm, wing' (Doak 1997 p 40):::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n622/mode/2up:::page 609 (457)
 ls:::=cin-čt:::=tsin-cht:::'wrist, edge of hand' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n638/mode/2up:::page 625 (557)
 ls:::=cin-kʷɛʔ:::=tsin-kwe':::'shore (edge of water)' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n638/mode/2up:::page 625 (559)
 ls:::=čaʔ:::=cha':::No gloss :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n634/mode/2up:::page 621 (527)
 ls:::=cin:::=tsin:::'edge, mouth, shore' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n624/mode/2up:::page 611 (475)
-ls:::=cɛn:::=tsen:::variant of =cin:::variant:::variant
-ls:::=cən:::=tsn:::variant of =cin:::variant:::variant
+ls:::=cɛn:::=tsen:::variant of =cin:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n624/mode/2up:::variant
+ls:::=cən:::=tsn:::variant of =cin:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n624/mode/2up:::variant
 ls:::=ɛl:::=el:::'planes meet' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n651/mode/2up:::p 836 [638] (610)
 ls:::=ɛls:::=els:::'round object' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n634/mode/2up:::page 621 (522)
 ls:::=ɛlwis:::=elwis:::'about, go about to indefinite places' locative suffix :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n635/mode/2up:::page 622 (532)
-ls:::=ɛl'w'əs:::=e'l'ws:::variant of =ɛlwis:::variant:::variant
-ls:::=ɛlwəs:::=elws:::variant of =ɛlwis:::variant:::variant
+ls:::=ɛl'w'əs:::=e'l'ws:::variant of =ɛlwis:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n635/mode/2up:::variant
+ls:::=ɛlwəs:::=elws:::variant of =ɛlwis:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n635/mode/2up:::variant
 ls:::=ɛɫniw':::=eɫni'w:::'alongside at rest, or in position alongside' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2up:::page 623 (535)
-ls:::=ɫniw':::=ɫni'w:::variant of =ɛɫniw':::variant:::variant
-ls:::=ɛɫnɛw':::=eɫne'w:::variant of =ɛɫniw':::variant:::variant
+ls:::=ɫniw':::=ɫni'w:::variant of =ɛɫniw':::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2up:::variant
+ls:::=ɛɫnɛw':::=eɫne'w:::variant of =ɛɫniw':::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2upt:::variant
 ls:::=ɛɫp:::=eɫp:::'part of a bush, plant, root, tree' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n623/mode/2up:::page 610 (469)
-ls:::=aɫp:::=aɫp:::variant of =ɛɫp:::variant:::variant
-ls:::=əɫp:::=ɫp:::variant of =ɛɫp:::variant:::variant
+ls:::=aɫp:::=aɫp:::variant of =ɛɫp:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n623/mode/2up:::variant
+ls:::=əɫp:::=ɫp:::variant of =ɛɫp:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n623/mode/2up:::variant
 ls:::=ɛməš:::=emsh:::'born' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n622/mode/2up:::page 609 (462)
-ls:::=əməš:::=msh:::variant of =ɛməš:::variant:::variant
-ls:::=məš:::=msh:::variant of =ɛməš:::variant:::variant
+ls:::=əməš:::=msh:::variant of =ɛməš:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n622/mode/2up:::variant
+ls:::=məš:::=msh:::variant of =ɛməš:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n622/mode/2up:::variant
 ls:::=ɛsčičɛʔ:::=eschiche':::'horse, stock' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n628/mode/2up:::page 615 (495)
 ls:::=ɛt:::=et:::'open to question, doubtful' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n634/mode/2up:::page 621 (524)
 ls:::=gwil:::=gwil:::'hollow object, wagon, canoe, abdomen' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n627/mode/2up:::page 614 (492)
-ls:::=gwəl:::=gwl:::variant of =gwil:::variant:::variant
+ls:::=gwəl:::=gwl:::variant of =gwil:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n627/mode/2up:::variant
 ls:::=ic'ɛʔ:::=its'e':::'all around, all over, used especially for wrapping or covering' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n635/mode/2up:::page 622 (533)
-ls:::=c'ɛʔ:::=ts'e':::variant of =ic'ɛʔ:::variant:::variant
+ls:::=c'ɛʔ:::=ts'e':::variant of =ic'ɛʔ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n635/mode/2up:::variant
 ls:::=ičn'-čt:::=ich'n-cht:::'back of hand' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n638/mode/2up:::page 625 (556)
 ls:::=ičn':::=ich'n:::'back, ridge' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n622/mode/2up:::page 609 (459)
-ls:::=ɛčn':::=ech'n:::variant of =ičn':::variant:::variant
-ls:::=əčn':::=ch'n:::variant of =ičn':::variant:::variant
+ls:::=ɛčn':::=ech'n:::variant of =ičn':::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n622/mode/2up:::variant
+ls:::=əčn':::=ch'n:::variant of =ičn':::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n622/mode/2up:::variant
 ls:::=ičs:::=ichs:::'hand, not including fingers' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n626/mode/2up:::page 613 (488)
-ls:::=ɛčs:::=echs:::variant of =ičs:::variant:::variant
-ls:::=čs:::=chs:::variant of =ičs:::variant:::variant
+ls:::=ɛčs:::=echs:::variant of =ičs:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n626/mode/2up:::variant
+ls:::=čs:::=chs:::variant of =ičs:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n626/mode/2up:::variant
 ls:::=ičt:::=icht:::'hand, including fingers' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n626/mode/2up:::page 613 (487)
-ls:::=ɛčt:::=echt:::variant of =ičt:::variant:::variant
-ls:::=čt:::=cht:::variant of =ičt:::variant:::variant
+ls:::=ɛčt:::=echt:::variant of =ičt:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n626/mode/2up:::variant
+ls:::=čt:::=cht:::variant of =ičt:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n626/mode/2up:::variant
 ls:::=iɫ-čɛʔ-us:::=iɫ-che'-us:::'inside of face (eye)' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n638/mode/2up:::page 625 (558)
 ls:::=idən:::=idn:::'effort' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n624/mode/2up:::page 611 (476)
 ls:::=il'č':::=i'lch':::check (?) :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n634/mode/2up:::page 621 (526)
-ls:::=ɛl'č':::=e'lch':::variant of =il'č':::variant:::variant
+ls:::=ɛl'č':::=e'lch':::variant of =il'č':::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n634/mode/2up:::variant
 ls:::=ilgwɛs:::=ilgwes:::'property' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n630/mode/2up:::page 617 (508)
-ls:::=ɛlgwɛs:::=elgwes:::variant of =ilgwɛs:::variant:::variant
+ls:::=ɛlgwɛs:::=elgwes:::variant of =ilgwɛs:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n630/mode/2up:::variant
 ls:::=il'kʷɛʔ:::=i'lkwe':::'forehead, brow' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n626/mode/2up:::page 613 (484)
 ls:::=il:::=il:::'angle where two planes meet' or 'place where two elements meet  :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n621/mode/2up:::page 608 (453)
-ls:::=ɛl:::=el:::variant of =il:::variant:::variant
-ls:::=l:::=l:::variant of=il:::variant:::variant
+ls:::=ɛl:::=el:::variant of =il:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n621/mode/2up:::variant
+ls:::=l:::=l:::variant of=il:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n621/mode/2up:::variant
 ls:::=iln:::=iln:::'food, pertaining to food' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n625/mode/2up:::page 612 (483)
-ls:::=ilən:::=iln:::variant of =iln:::variant:::variant
+ls:::=ilən:::=iln:::variant of =iln:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n625/mode/2up:::variant
 ls:::=iɫ:::=iɫ:::'direction, -ward' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2up:::page 623 (539)
 ls:::=ilps:::=ilps:::'throat of person, back of animal's neck' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n631/mode/2up:::page 618 (514)
-ls:::=ɛlps:::=elps:::variant of =ilps:::variant:::variant
+ls:::=ɛlps:::=elps:::variant of =ilps:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n631/mode/2up:::variant
 ls:::=ilqwɛs:::=ilqwes:::'heart, stomach' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n627/mode/2up:::page 614 (490)
-ls:::=ɛlqwɛs:::=elqwes:::variant of =ilqwɛs:::variant:::variant
+ls:::=ɛlqwɛs:::=elqwes:::variant of =ilqwɛs:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n627/mode/2up:::variant
 ls:::=ilt:::=ilt:::'offspring, child' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n629/mode/2up:::page 616 (502)
-ls:::=ɛlt:::=elt:::variant of =ilt:::variant:::variant
-ls:::=ɛl't:::=e'lt:::variant of =ilt:::variant:::variant
+ls:::=ɛlt:::=elt:::variant of =ilt:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n629/mode/2up:::variant
+ls:::=ɛl't:::=e'lt:::variant of =ilt:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n629/mode/2up:::variant
 ls:::=iləmxʷ:::=ilmkhw:::'person, man' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n630/mode/2up:::page 617 (504)
-ls:::=aləmxʷ:::=almkhw:::variant of =iləmxʷ:::variant:::variant
-ls:::=ɛləmxʷ:::=elmkhw:::variant of =iləmxʷ:::variant:::variant
+ls:::=aləmxʷ:::=almkhw:::variant of =iləmxʷ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n630/mode/2up:::variant
+ls:::=ɛləmxʷ:::=elmkhw:::variant of =iləmxʷ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n630/mode/2up:::variant
 ls:::=ilup:::=ilup:::'foundation, something on which to rest' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n626/mode/2up:::page 613 (485)
-ls:::=ɛlup:::=elup:::variant of =ilup:::variant:::variant
+ls:::=ɛlup:::=elup:::variant of =ilup:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n626/mode/2up:::variant
 ls:::=inɛʔ:::=ine':::'ear' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n624/mode/2up:::page 611 (473)
-ls:::=ɛnɛʔ:::=ene':::variant of =inɛʔ:::variant:::variant
-ls:::=ɛnɛʔ:::=ene':::variant of =inɛʔ:::variant:::variant
+ls:::=ɛnɛʔ:::=ene':::variant of =inɛʔ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n624/mode/2up:::variant
+ls:::=ɛnɛʔ:::=ene':::variant of =inɛʔ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n624/mode/2up:::variant
 ls:::=iʔ:::=i':::'someone who ... for' used with kin terms, no clear meaning :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n634/mode/2up:::page 621 (528)
-ls:::=ɛʔ:::=e':::variant of =iʔ:::variant:::variant
+ls:::=ɛʔ:::=e':::variant of =iʔ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n634/mode/2up:::variant
 ls:::=ilxʷ:::=ilkhw:::'hide, skin, mat, covering' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n627/mode/2up:::page 614 (491)
-ls:::=ɛlxʷ:::=elkhw:::variant of =ilxʷ:::variant:::variant
-ls:::=lxʷ:::=lkhw:::variant of =ilxʷ:::variant:::variant
+ls:::=ɛlxʷ:::=elkhw:::variant of =ilxʷ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n627/mode/2up:::variant
+ls:::=lxʷ:::=lkhw:::variant of =ilxʷ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n627/mode/2up:::variant
 ls:::=inč:::=inch:::'hollow, whence: belly' with hn- (locative 'in, onto, etc.') 'room' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n628/mode/2up:::page 615 (493)
-ls:::=ɛnč:::=ench:::variant of =inč:::variant:::variant
+ls:::=ɛnč:::=ench:::variant of =inč:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n628/mode/2up:::variant
 ls:::=ingʷilən:::=ingwiln:::'something' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n631/mode/2up:::page 618 (512)
 ls:::=inɛʔ:::=ine':::'over, on top of but not entirely covered' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2up:::page 623 (541)
-ls:::=ɛnɛʔ:::=ene':::variant of =inɛʔ:::variant:::variant
-ls:::=ɛnɛʔ:::=ene':::variant of =inɛʔ:::variant:::variant
+ls:::=ɛnɛʔ:::=ene':::variant of =inɛʔ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2up:::variant
+ls:::=ɛnɛʔ:::=ene':::variant of =inɛʔ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2up:::variant
 ls:::=ins:::=ins:::'tooth' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n632/mode/2up:::page 619 (516)
-ls:::=ɛns:::=ens:::variant of =ins:::variant:::variant
+ls:::=ɛns:::=ens:::variant of =ins:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n632/mode/2up:::variant
 ls:::=inxʷ:::=inkhw:::'weather' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n633/mode/2up:::page 620 (520)
-ls:::=ɛnxʷ:::=enkhw:::variant of =inxʷ:::variant:::variant
+ls:::=ɛnxʷ:::=enkhw:::variant of =inxʷ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n633/mode/2up:::variant
 ls:::=iplɛʔ:::=iple':::'attachment, handle. connection' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n622/mode/2up:::page 609 (458)
-ls:::=aplɛʔ:::=aple':::variant of =iplɛʔ:::variant:::variant
-ls:::=ɛplɛʔ:::=eple':::variant of =iplɛʔ:::variant:::variant
+ls:::=aplɛʔ:::=aple':::variant of =iplɛʔ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n622/mode/2up:::variant
+ls:::=ɛplɛʔ:::=eple':::variant of =iplɛʔ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n622/mode/2up:::variant
 ls:::=ip-ɛl-sčən:::=ip-el-schn:::'stubby horn, stump of horn' (?) :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n637/mode/2up:::page 624 (549)
 ls:::=iplɛʔšən:::=iple'shn:::'heel (handle of foot)' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n638/mode/2up:::page 625 (554)
 ls:::=ip:::=ip:::'bottom, after, behind, back' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n623/mode/2up:::page 610 (463)
-ls:::=ap:::=ap:::variant of =ip:::variant:::variant
-ls:::=ɛp:::=ep:::variant of =ip:::variant:::variant
-ls:::=p:::=p:::variant of =ip:::variant:::variant
+ls:::=ap:::=ap:::variant of =ip:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n623/mode/2up:::variant
+ls:::=ɛp:::=ep:::variant of =ip:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n623/mode/2up:::variant
+ls:::=p:::=p:::variant of =ip:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n623/mode/2up:::variant
 ls:::=ip-ɛns:::=ip-ens:::'chin, i.e. bottom of teeth' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n637/mode/2up:::page 624 (548)
 ls:::=ips:::=ips:::'neck all around' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n629/mode/2up:::page 616 (500)
-ls:::=ɛps:::=eps:::variant of =ips:::variant:::variant
+ls:::=ɛps:::=eps:::variant of =ips:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n629/mode/2up:::variant
 ls:::=ipɫtixʷcč:::=ipɫtikhwtsch:::'tongue, tongue-shaped' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n632/mode/2up:::page 619 (515)
-ls:::=ɛpɫtixʷcč:::=epɫtikhwtsch:::variant of =ipɫtixʷcč:::variant:::variant
+ls:::=ɛpɫtixʷcč:::=epɫtikhwtsch:::variant of =ipɫtixʷcč::::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n632/mode/2up:::variant
 ls:::=ip-w'as-šən:::=ip-'was-shn:::'the generalized word for privates' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n638/mode/2up:::page 625 (555)
 ls:::=isčən:::=ischn:::'horn, forehead at the edge of the hair' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n628/mode/2up:::page 615 (494)
-ls:::=sčən:::=schn:::variant of =isčən:::variant:::variant
+ls:::=sčən:::=schn:::variant of =isčən:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n628/mode/2up:::variant
 ls:::=isč'ɛy't:::=isch'e'yt:::'pharynx' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n630/mode/2up:::page 617 (507)
 ls:::=isgwɛl:::=isgwel:::'fish' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n625/mode/2up:::page 612 (481)
-ls:::=sgwɛl:::=sgwel:::variant of =isgwɛl:::variant:::variant
+ls:::=sgwɛl:::=sgwel:::variant of =isgwɛl:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n625/mode/2up:::variant
 ls:::=itkʷɛʔ:::=itkwe':::'water' (Doak 1997 p 31)::: ::: 
 ls:::=i'utəm:::=i'utm:::'self-doer, auto-, that which performs by itself, a neuter reflexive, not applied to persons' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n631/mode/2up:::page 618 (510)
 ls:::=iw'ɛs:::=i'wes:::'between, together, have contact with, be in contact' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2up:::page 623 (537)
-ls:::=aw'ɛs:::=a'wes:::variant of =iw'ɛs:::variant:::variant
-ls:::=ɛw'ɛs:::=e'wes:::variant of =iw'ɛs:::variant:::variant
+ls:::=aw'ɛs:::=a'wes:::variant of =iw'ɛs:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2up:::variant
+ls:::=ɛw'ɛs:::=e'wes:::variant of =iw'ɛs:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2up:::variant
 ls:::=iɫc'ɛʔ:::=iɫts'e':::'body' (Doak 1997 p 96; 75a)::: ::: 
 ls:::=iɫxʷ:::=iɫkhw:::'house' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n628/mode/2up:::page 615 (496)
-ls:::=ɫxʷ:::=ɫkhw:::variant of =iɫxʷ:::variant:::variant
+ls:::=ɫxʷ:::=ɫkhw:::variant of =iɫxʷ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n628/mode/2up:::variant
 ls:::=ixʷ:::=ikhw:::'willingly, of own accord' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n621/mode/2up:::page 608 (455)
-ls:::=ɛxʷ:::=ekhw:::variant of =ixʷ:::variant:::variant
-ls:::=xʷ:::=khw:::variant of =ixʷ:::variant:::variant
+ls:::=ɛxʷ:::=ekhw:::variant of =ixʷ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n621/mode/2up:::variant
+ls:::=xʷ:::=khw:::variant of =ixʷ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n621/mode/2up:::variant
 ls:::=iʔst:::=i'st:::'surface of round object, rock' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n631/mode/2up:::page 618 (513)
-ls:::=aʔst:::=a'st:::variant of =iʔst:::variant:::variant
-ls:::=ɛʔst:::=e'st:::variant of =iʔst:::variant:::variant
+ls:::=aʔst:::=a'st:::variant of =iʔst:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n631/mode/2up:::variant
+ls:::=ɛʔst:::=e'st:::variant of =iʔst:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n631/mode/2up:::variant
 ls:::=iʔt:::=i't:::'source (?)' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n634/mode/2up:::page 621 (523)
-ls:::=ɛʔt:::=e't:::variant of =iʔt:::variant:::variant
+ls:::=ɛʔt:::=e't:::variant of =iʔt:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n634/mode/2up:::variant
 ls:::=kʷup:::=kwup:::'wood (?)' (Doak 1997 p 40)::: ::: 
 ls:::=kʷɛʔ:::=kwe':::'water, liquid' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n632/mode/2up:::page 619 (519)
 ls:::=kəp:::=kp:::'fire, fuel' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n625/mode/2up:::page 612 (480)
@@ -163,33 +163,33 @@ ls:::=mɛʔ:::=me':::'in every way' :::http://www.archive.org/stream/rosettaproj
 ls:::=num':::=nu'm:::'body' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n622/mode/2up:::page 609 (461)
 ls:::=os-ax̣ɛn:::=os-aqhen:::'top of arm, perhaps ball and socket joint' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n637/mode/2up:::page 624 (545)
 ls:::=qin:::=qin:::'head, tip, top' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n627/mode/2up:::page 614 (489)
-ls:::=qən:::=qn:::variant of =qin:::variant:::variant
-ls:::=qən:::=qn:::variant of =qin:::variant:::variant
+ls:::=qən:::=qn:::variant of =qin:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n627/mode/2up:::variant
+ls:::=qən:::=qn:::variant of =qin:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n627/mode/2up:::variant
 ls:::=qin:::=qin:::'voice, throat' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n632/mode/2up:::page 619 (518)
-ls:::=qən:::=qn:::variant of =qin:::variant:::variant
-ls:::=qən:::=qn:::variant of =qin:::variant:::variant
+ls:::=qən:::=qn:::variant of =qin:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n632/mode/2up:::variant
+ls:::=qən:::=qn:::variant of =qin:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n632/mode/2up:::variant
 ls:::=qinəps:::=qinps:::'seat' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n637/mode/2up:::page 624 (544)
 ls:::=stq:::=stq:::'seems to refer to vegetation crops' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n632/mode/2up:::page 619 (517)
 ls:::=sčint:::=schint:::'people, persons' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n630/mode/2up:::page 617 (505)
-ls:::=sčɛnt:::=schent:::variant of =sčint:::variant:::variant
+ls:::=sčɛnt:::=schent:::variant of =sčint:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n630/mode/2up:::variant
 ls:::=əmš:::=msh:::'people as a kind of group' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n630/mode/2up:::page 617 (506)
 ls:::=šin:::=shin:::'foot, leg, the leg from hip to toe' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n625/mode/2up:::page 612 (482)
-ls:::=šɛn:::=shen:::variant of =šin:::variant:::variant
-ls:::=šən:::=shn:::variant of =šin:::variant:::variant
+ls:::=šɛn:::=shen:::variant of =šin:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n625/mode/2up:::variant
+ls:::=šən:::=shn:::variant of =šin:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n625/mode/2up:::variant
 ls:::=tx̣ʷɛ:::=tqhwe:::'camas, (?)' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n623/mode/2up:::page 610 (470)
 ls:::=t'ɛy't:::=t'e'yt:::No gloss :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n634/mode/2up:::page 621 (525)
 ls:::=ul'əmxʷ:::=u'lmkhw:::'ground' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n626/mode/2up:::page 613 (486)
 ls:::=ups:::=ups:::'anus, anal region' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n621/mode/2up:::page 608 (456)
 ls:::=us:::=us:::'face, fire, eye' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n625/mode/2up:::page 612 (478)
-ls:::=os:::=os:::variant of =us:::variant:::variant
-ls:::=s:::=s:::variant of =us:::variant:::variant
+ls:::=os:::=os:::variant of =us:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n625/mode/2up:::variant
+ls:::=s:::=s:::variant of =us:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n625/mode/2up:::variant
 ls:::=ut:::=ut:::'place' (Doak 1997 p 28)::: ::: 
 ls:::=us-šən:::=us-shn:::'toe (face of foot)' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n638/mode/2up:::page 625 (553)
 ls:::=ust:::=ust:::'along, meaning movement along' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2up:::page 623 (534)
 ls:::=uʔ:::=u':::'pendent'  :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n629/mode/2up:::page 616 (503)
 ls:::=uʔus:::=u'us:::'directly, spang' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n635/mode/2up:::page 623 (538)
-ls:::=oʔos:::=o'os:::variant of =uʔus:::variant:::variant
+ls:::=oʔos:::=o'os:::variant of =uʔus:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n635/mode/2up:::variant
 ls:::=iʔqs:::=i'qs:::'nose, beak, oral and nasal cavity, seat of taste' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n629/mode/2up:::page 616 (501)
-ls:::=ʔqs:::='qs:::variant of =iʔqs:::variant:::variant
+ls:::=ʔqs:::='qs:::variant of =iʔqs:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n629/mode/2up:::variant
 ls:::=yuyɛʔ:::=yuye':::'back and forth' :::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2up:::page 623 (536)
-ls:::=yoyɛʔ:::=yoye':::variant of =yuyɛʔ:::variant:::variant
+ls:::=yoyɛʔ:::=yoye':::variant of =yuyɛʔ:::http://www.archive.org/stream/rosettaproject_tqw_morsyn-2#page/n636/mode/2up:::variant

--- a/data/stems_both_lists.txt
+++ b/data/stems_both_lists.txt
@@ -1,1289 +1,1289 @@
-v:::a:::atsqä'<sup>ä</sup>:::ʔacqeʔ:::acqaʔ:::atsqa':::go out, singular and plural:::note:::acqaʔ
-v:::a:::ats̕x̣:::ʔac'x̣:::ac'x̣:::ats'qh:::look at:::note:::ac'x̣
-v:::a:::ayx̣ʷ:::ʔayx̣ʷ:::ayx̣ʷ(-t):::ayqhw(-t):::be tired:::note:::ayx̣ʷ(-t)
-v:::a:::ax̣il:::ʔax̣il:::ax̣il:::aqhil:::do thus:::note:::ax̣il
-v:::a:::aṛʷ:::ʔaʕʷ:::aʕʷ:::a(w:::be much, many:::note:::aʕʷ
-v:::ɛ/e:::äpɬ:::ʔepɬ:::ɛpɫ:::epɫ:::there is, have:::note:::ɛpɫ
-v:::ɛ/e:::äw:::ʔew:::ɛw(-t):::ew(-t):::oppose:::note:::ɛw(-t)
-v:::ɛ/e:::äm:::ʔem:::ɛm(-t):::em(-t):::share, feed:::note:::ɛm(-t)
+﻿v:::a:::atsqä'<sup>ä</sup>:::ʔacqeʔ:::acqaʔ:::atsqa':::go out, singular and plural::: :::acqaʔ
+v:::a:::ats̕x̣:::ʔac'x̣:::ac'x̣:::ats'qh:::look at::: :::ac'x̣
+v:::a:::ayx̣ʷ:::ʔayx̣ʷ:::ayx̣ʷ(-t):::ayqhw(-t):::be tired::: :::ayx̣ʷ(-t)
+v:::a:::ax̣il:::ʔax̣il:::ax̣il:::aqhil:::do thus::: :::ax̣il
+v:::a:::aṛʷ:::ʔaʕʷ:::aʕʷ:::a(w:::be much, many::: :::aʕʷ
+v:::ɛ/e:::äpɬ:::ʔepɬ:::ɛpɫ:::epɫ:::there is, have::: :::ɛpɫ
+v:::ɛ/e:::äw:::ʔew:::ɛw(-t):::ew(-t):::oppose::: :::ɛw(-t)
+v:::ɛ/e:::äm:::ʔem:::ɛm(-t):::em(-t):::share, feed::: :::ɛm(-t)
 v:::ɛ/e:::äm:::ʔem:::ɛm:::em:::one sits:::omitted from file; Reichard 1939 p. 92:::ɛm
-v:::ɛ/e:::äkʷn:::ʔekʷn:::ɛkʷn:::ekwn:::say, tell:::note:::ɛkʷn
-v:::ɛ/e:::äx-us:::ʔexʷ-us:::ɛx-us:::ekh-us:::look for, hunt:::note:::ɛx-us
-v:::ɛ/e:::änis:::ʔenis:::ɛnis:::enis:::leave, set out, go away:::note:::ɛnis
-v:::ɛ/e:::äsil:::ʔesil:::ɛsil:::esil:::two:::note:::ɛsil
-v:::ɛ/e:::ätcän̕:::ʔečen̕:::ɛčɛn':::eche'n:::tie up sack:::note:::ɛčɛn'
-v:::ɛ/e:::ängwät:::ʔengʷet:::ɛngʷɛt:::engwet:::belong to:::note:::ɛngʷɛt
-v:::ɛ/e:::ätcin:::ʔečin:::ɛčin:::echin:::do with, put, be the matter:::note:::ɛčin
-v:::ɛ/e:::äl:::ʔel:::ɛl:::el:::move body:::note:::ɛl
-v:::i:::ip̕:::ʔip̕:::ip':::ip':::wipe:::note:::ip'
-v:::i:::im:::ʔim:::im:::im:::try:::note:::im
-v:::i:::im:::ʔim:::im:::im:::gather together:::note:::im
-v:::i:::id:::ʔid:::id:::id:::exchange, barter:::note:::id
-v:::i:::ingwät:::ʔingʷet:::ingʷɛt:::ingwet:::be who, what:::note:::ingʷɛt
-v:::i:::idxʷ:::ʔidxʷ:::idxʷ:::idkhw:::be in form of cross:::note:::idxʷ
-v:::i:::itstc:::ʔicč:::icč:::itsch:::play:::note:::icč
-v:::i:::igw:::ʔigʷ:::igʷ:::igw:::set out for:::note:::igʷ
-v:::i:::ttc̕-ígwụl:::t-č̕igʷl:::tč'-i'gʷəl:::tch'-i'gwl:::climb:::note:::tč'-i'gʷəl
-v:::i:::ixʷụl:::ʔixʷl:::ixʷəl:::ikhwl:::be some:::note:::ixʷəl
-v:::i:::ilk̕ʷ:::ʔilk̕ʷ:::ilk'ʷ:::ilk'w:::store new acquisition:::note:::ilk'ʷ
-v:::i:::iɬn:::ʔiɬn:::iɫn:::iɫn:::eat:::note:::iɫn
-v:::u, ɔ/o:::upEn:::ʔupn:::upən:::upn:::ten:::note:::upən
-v:::u, ɔ/o:::us-ɩlc:::ʔus-lš:::us-əlš:::us-lsh:::dive from land (face in horseshoe curve):::note:::us-əlš
-v:::u, ɔ/o:::utskʷ:::ʔuckʷ:::uckʷ:::utskw:::bathe, person swims:::note:::uckʷ
-v:::u, ɔ/o:::ukʷ:::ʔukʷ:::ukʷ:::ukw:::carry, bring:::note:::ukʷ
-v:::u, ɔ/o:::ukʷt:::ʔukʷt:::ukʷt:::ukwt:::crawl:::note:::ukʷt
-v:::u, ɔ/o:::ɔqʷs:::ʔoqʷs:::ɔqʷs:::oqws:::drink:::note:::ɔqʷs
-v:::u, ɔ/o:::ɔh-i'<sup>ɩ</sup>t:::ʔoh-iʔt:::ɔh-iʔt:::oh-i't:::have a cold:::note:::ɔh-iʔt
-v:::u, ɔ/o:::ɔr:::ʔor:::ɔr(-t):::or(-t):::be frozen stiff:::note:::ɔr(-t)
-v:::b:::bam:::bam:::bam:::bam:::be intoxicated, be versatile:::note:::bam
-v:::b:::bäm:::bem:::bɛm:::bem:::buzz:::note:::bɛm
-v:::b:::bum:::bum:::bum:::bum:::speed (used of drunks):::note:::bum
-v:::b:::buts:::buc:::buc:::buts:::be boots (Eng. used for rubber boots):::note:::buc
-v:::b:::bam:::ʔuubám:::bam(u-):::bam(u-):::go fast and far:::note:::bam(u-)
-v:::p:::pa'axʷ:::paʔx̣:::paʔax̣:::pa'aqh:::think over (cp pax̣ be wise):::note:::paʔax̣
-v:::p:::paw̕:::paw̕:::paw':::pa'w:::drum on drum:::note:::paw'
-v:::p:::patx̣ʷ:::patx̣ʷ:::patx̣ʷ:::patqhw:::burst forth (as oil, water, pus):::note:::patx̣ʷ 
-v:::p:::pas:::pas:::pas:::pas:::be astonished, bewildered, amaze, wonder:::note:::pas
-v:::p:::pa'as:::paʔs:::paʔas:::pas:::come to surface (cp. pas be astonished):::note:::pas
-v:::p:::pan̕:::pan̕:::pan':::pa'n:::be spouse:::note:::pan'
-v:::p:::pax̣:::pax̣:::pax̣:::paqh:::be wise, think, reflect - -t, tell myths:::note:::pax̣
-v:::p:::pax̣:::pax̣:::pax̣:::paqh:::rub on rough surface (as strike match):::note:::pax̣
-v:::p:::pax̣ʷ:::pax̣ʷ:::pax̣ʷ:::paqhw:::scatter, distribute in order:::note:::pax̣ʷ
-v:::p:::par:::par:::par:::par:::be white with powder:::note:::par
-v:::p:::parq̕	(parq̕):::parq':::sail:::parq':::be curved:::note:::parq'
-v:::p:::par̕kʷ:::par̕kʷ:::par'kʷ:::pa'rkw:::pierce:::note:::par'kʷ
-v:::p:::paṛʷ:::paʕʷ:::paʕʷ:::pa(w:::defecate:::note:::paʕʷ
-v:::p:::päw̕:::pew̕:::pɛw':::pe'w:::drum on tin:::note:::pɛw'
-v:::p:::pätqʷ:::petqʷ:::pɛtqʷ:::petqw:::race:::note:::pɛtqʷ
-v:::p:::pä<sup>ä</sup>st-ä'<sup>ä</sup>:::pesteʔ:::pɛst-ɛʔ:::pest-e':::be half, one side:::note:::pɛst-ɛʔ
-v:::p:::pän̕:::pen̕:::pɛn':::pe'n:::bend, be bent:::note:::pɛn'
-v:::p:::päy̕-piy̕:::piy̕:::pɛy'-piy'(-t):::pe'y-pi'y(-t):::be delightful (cp. piy be happy):::note:::pɛy'-piy'(-t)
-v:::p:::päkʷ:::pekʷ:::pɛkʷ:::pekw:::lay pl. round objects:::note:::pɛkʷ
-v:::p:::päxʷ:::pexʷ:::pɛxʷ:::pekhw:::get small catch of fish:::note:::pɛxʷ
-v:::p:::päxʷ:::pexʷ:::pɛxʷ:::pekhw:::wind-blown:::note:::pɛxʷ
-v:::p:::päq:::peq:::pɛq:::peq:::white, bleached, silver:::note:::pɛq
-v:::p:::tᴇ-päx̣ʷ:::tepex̣ʷ:::tə-pɛx̣ʷ:::t-peqhw:::spit, saliva:::note:::tə-pɛx̣ʷ
-v:::p:::päɬ:::peɬ:::pɛɫ:::peɫ:::be thick layer:::note:::pɛɫ
-v:::p:::pär̕kʷ:::per̕kʷ:::pɛr'kʷ:::pe'rkw:::nail:::note:::pɛr'kʷ
-v:::p:::päṛʷ:::peʕʷ:::pɛʕʷ:::pe(w:::be surplus, plus:::note:::pɛʕʷ
-v:::p:::piw̕:::piw̕:::piw':::pi'w:::move in jerks:::note:::piw'
-v:::p:::piw̕:::piw̕:::piw':::pi'w:::be light in weight (perhaps same as preceding):::note:::piw'
-v:::p:::pis:::pis:::pis:::pis:::pl. objects are big:::note:::pis
-v:::p:::pitsxʷ:::picxʷ:::picxʷ(-t):::pitskhw(-t):::become angry with defeat or discouragement:::note:::picxʷ(-t)
-v:::p:::piy:::piy:::piy:::piy:::be happy:::note:::piy
+v:::ɛ/e:::äkʷn:::ʔekʷn:::ɛkʷn:::ekwn:::say, tell::: :::ɛkʷn
+v:::ɛ/e:::äx-us:::ʔexʷ-us:::ɛx-us:::ekh-us:::look for, hunt::: :::ɛx-us
+v:::ɛ/e:::änis:::ʔenis:::ɛnis:::enis:::leave, set out, go away::: :::ɛnis
+v:::ɛ/e:::äsil:::ʔesil:::ɛsil:::esil:::two::: :::ɛsil
+v:::ɛ/e:::ätcän̕:::ʔečen̕:::ɛčɛn':::eche'n:::tie up sack::: :::ɛčɛn'
+v:::ɛ/e:::ängwät:::ʔengʷet:::ɛngʷɛt:::engwet:::belong to::: :::ɛngʷɛt
+v:::ɛ/e:::ätcin:::ʔečin:::ɛčin:::echin:::do with, put, be the matter::: :::ɛčin
+v:::ɛ/e:::äl:::ʔel:::ɛl:::el:::move body::: :::ɛl
+v:::i:::ip̕:::ʔip̕:::ip':::ip':::wipe::: :::ip'
+v:::i:::im:::ʔim:::im:::im:::try::: :::im
+v:::i:::im:::ʔim:::im:::im:::gather together::: :::im
+v:::i:::id:::ʔid:::id:::id:::exchange, barter::: :::id
+v:::i:::ingwät:::ʔingʷet:::ingʷɛt:::ingwet:::be who, what::: :::ingʷɛt
+v:::i:::idxʷ:::ʔidxʷ:::idxʷ:::idkhw:::be in form of cross::: :::idxʷ
+v:::i:::itstc:::ʔicč:::icč:::itsch:::play::: :::icč
+v:::i:::igw:::ʔigʷ:::igʷ:::igw:::set out for::: :::igʷ
+v:::i:::ttc̕-ígwụl:::t-č̕igʷl:::tč'-i'gʷəl:::tch'-i'gwl:::climb::: :::tč'-i'gʷəl
+v:::i:::ixʷụl:::ʔixʷl:::ixʷəl:::ikhwl:::be some::: :::ixʷəl
+v:::i:::ilk̕ʷ:::ʔilk̕ʷ:::ilk'ʷ:::ilk'w:::store new acquisition::: :::ilk'ʷ
+v:::i:::iɬn:::ʔiɬn:::iɫn:::iɫn:::eat::: :::iɫn
+v:::u, ɔ/o:::upEn:::ʔupn:::upən:::upn:::ten::: :::upən
+v:::u, ɔ/o:::us-ɩlc:::ʔus-lš:::us-əlš:::us-lsh:::dive from land (face in horseshoe curve)::: :::us-əlš
+v:::u, ɔ/o:::utskʷ:::ʔuckʷ:::uckʷ:::utskw:::bathe, person swims::: :::uckʷ
+v:::u, ɔ/o:::ukʷ:::ʔukʷ:::ukʷ:::ukw:::carry, bring::: :::ukʷ
+v:::u, ɔ/o:::ukʷt:::ʔukʷt:::ukʷt:::ukwt:::crawl::: :::ukʷt
+v:::u, ɔ/o:::ɔqʷs:::ʔoqʷs:::ɔqʷs:::oqws:::drink::: :::ɔqʷs
+v:::u, ɔ/o:::ɔh-i'<sup>ɩ</sup>t:::ʔoh-iʔt:::ɔh-iʔt:::oh-i't:::have a cold::: :::ɔh-iʔt
+v:::u, ɔ/o:::ɔr:::ʔor:::ɔr(-t):::or(-t):::be frozen stiff::: :::ɔr(-t)
+v:::b:::bam:::bam:::bam:::bam:::be intoxicated, be versatile::: :::bam
+v:::b:::bäm:::bem:::bɛm:::bem:::buzz::: :::bɛm
+v:::b:::bum:::bum:::bum:::bum:::speed (used of drunks)::: :::bum
+v:::b:::buts:::buc:::buc:::buts:::be boots (Eng. used for rubber boots)::: :::buc
+v:::b:::bam:::ʔuubám:::bam(u-):::bam(u-):::go fast and far::: :::bam(u-)
+v:::p:::pa'axʷ:::paʔx̣:::paʔax̣:::pa'aqh:::think over (cp pax̣ be wise)::: :::paʔax̣
+v:::p:::paw̕:::paw̕:::paw':::pa'w:::drum on drum::: :::paw'
+v:::p:::patx̣ʷ:::patx̣ʷ:::patx̣ʷ:::patqhw:::burst forth (as oil, water, pus)::: :::patx̣ʷ 
+v:::p:::pas:::pas:::pas:::pas:::be astonished, bewildered, amaze, wonder::: :::pas
+v:::p:::pa'as:::paʔs:::paʔas:::pas:::come to surface (cp. pas be astonished)::: :::pas
+v:::p:::pan̕:::pan̕:::pan':::pa'n:::be spouse::: :::pan'
+v:::p:::pax̣:::pax̣:::pax̣:::paqh:::be wise, think, reflect - -t, tell myths::: :::pax̣
+v:::p:::pax̣:::pax̣:::pax̣:::paqh:::rub on rough surface (as strike match)::: :::pax̣
+v:::p:::pax̣ʷ:::pax̣ʷ:::pax̣ʷ:::paqhw:::scatter, distribute in order::: :::pax̣ʷ
+v:::p:::par:::par:::par:::par:::be white with powder::: :::par
+v:::p:::parq̕	(parq̕):::parq':::sail:::parq':::be curved::: :::parq'
+v:::p:::par̕kʷ:::par̕kʷ:::par'kʷ:::pa'rkw:::pierce::: :::par'kʷ
+v:::p:::paṛʷ:::paʕʷ:::paʕʷ:::pa(w:::defecate::: :::paʕʷ
+v:::p:::päw̕:::pew̕:::pɛw':::pe'w:::drum on tin::: :::pɛw'
+v:::p:::pätqʷ:::petqʷ:::pɛtqʷ:::petqw:::race::: :::pɛtqʷ
+v:::p:::pä<sup>ä</sup>st-ä'<sup>ä</sup>:::pesteʔ:::pɛst-ɛʔ:::pest-e':::be half, one side::: :::pɛst-ɛʔ
+v:::p:::pän̕:::pen̕:::pɛn':::pe'n:::bend, be bent::: :::pɛn'
+v:::p:::päy̕-piy̕:::piy̕:::pɛy'-piy'(-t):::pe'y-pi'y(-t):::be delightful (cp. piy be happy)::: :::pɛy'-piy'(-t)
+v:::p:::päkʷ:::pekʷ:::pɛkʷ:::pekw:::lay pl. round objects::: :::pɛkʷ
+v:::p:::päxʷ:::pexʷ:::pɛxʷ:::pekhw:::get small catch of fish::: :::pɛxʷ
+v:::p:::päxʷ:::pexʷ:::pɛxʷ:::pekhw:::wind-blown::: :::pɛxʷ
+v:::p:::päq:::peq:::pɛq:::peq:::white, bleached, silver::: :::pɛq
+v:::p:::tᴇ-päx̣ʷ:::tepex̣ʷ:::tə-pɛx̣ʷ:::t-peqhw:::spit, saliva::: :::tə-pɛx̣ʷ
+v:::p:::päɬ:::peɬ:::pɛɫ:::peɫ:::be thick layer::: :::pɛɫ
+v:::p:::pär̕kʷ:::per̕kʷ:::pɛr'kʷ:::pe'rkw:::nail::: :::pɛr'kʷ
+v:::p:::päṛʷ:::peʕʷ:::pɛʕʷ:::pe(w:::be surplus, plus::: :::pɛʕʷ
+v:::p:::piw̕:::piw̕:::piw':::pi'w:::move in jerks::: :::piw'
+v:::p:::piw̕:::piw̕:::piw':::pi'w:::be light in weight (perhaps same as preceding)::: :::piw'
+v:::p:::pis:::pis:::pis:::pis:::pl. objects are big::: :::pis
+v:::p:::pitsxʷ:::picxʷ:::picxʷ(-t):::pitskhw(-t):::become angry with defeat or discouragement::: :::picxʷ(-t)
+v:::p:::piy:::piy:::piy:::piy:::be happy::: :::piy
 v:::p:::pigw:::pigʷ:::pigʷ:::pigw:::swell, breathe:::(see √piw̕):::pigʷ
-v:::p:::piɬ:::piɬ:::piɫ:::piɫ:::be scattered:::note:::piɫ
+v:::p:::piɬ:::piɬ:::piɫ:::piɫ:::be scattered::: :::piɫ
 v:::p:::pih:::pih:::pih:::pih:::rise to surface, separate (as cream):::(only attested with C2 reduplication):::pih
-v:::p:::pu'us:::puʔs:::puʔus:::pu'us:::swell, bubble, ferment:::note:::puʔus
-v:::p:::put-ä'<sup>ä</sup>:::puteʔ:::put-ɛʔ:::put-e':::respect, honor, worship:::note:::put-ɛʔ
-v:::p:::pus:::pus:::pus(- -t):::pus(- -t):::be a nuisance:::note:::pus(- -t)
-v:::p:::pus:::pus:::pus:::pus:::be engrossed in digestion:::note:::pus
-v:::p:::pụ-pus-intc:::pupusínč:::pə-pus-inč:::p-pus-inch:::be sad, sorry, mournful (seems not to be dim.):::note:::pə-pus-inč
-v:::p:::puxʷ:::puxʷ:::puxʷ:::pukhw:::blow with mouth:::note:::puxʷ
-v:::p:::puqʷ-ilc:::pqʷil:::puqʷ-ilš:::puqw-ilsh:::come to observe:::note:::puqʷ-ilš
-v:::p:::pulut:::pulut:::pulut:::pulut:::kill, injure:::note:::pulut
-v:::p:::pulk̕ʷ (p̕ulk̕ʷ):::pulk'ʷ:::sail:::pulk'w:::fold sheetlike object:::note:::pulk'ʷ
-v:::p:::puɬ:::puɬ:::puɫ:::puɫ:::foam (prog. dis.):::note:::puɫ
-v:::p:::pɔs:::pos:::pɔs:::pos:::concentrate (also, 'comical' LN):::note:::pɔs
-v:::p:::pɩs-ic:::psíš:::pəs-iš:::ps-ish:::gather wood (cp. pis pl. are large):::note:::pəs-iš
+v:::p:::pu'us:::puʔs:::puʔus:::pu'us:::swell, bubble, ferment::: :::puʔus
+v:::p:::put-ä'<sup>ä</sup>:::puteʔ:::put-ɛʔ:::put-e':::respect, honor, worship::: :::put-ɛʔ
+v:::p:::pus:::pus:::pus(- -t):::pus(- -t):::be a nuisance::: :::pus(- -t)
+v:::p:::pus:::pus:::pus:::pus:::be engrossed in digestion::: :::pus
+v:::p:::pụ-pus-intc:::pupusínč:::pə-pus-inč:::p-pus-inch:::be sad, sorry, mournful (seems not to be dim.)::: :::pə-pus-inč
+v:::p:::puxʷ:::puxʷ:::puxʷ:::pukhw:::blow with mouth::: :::puxʷ
+v:::p:::puqʷ-ilc:::pqʷil:::puqʷ-ilš:::puqw-ilsh:::come to observe::: :::puqʷ-ilš
+v:::p:::pulut:::pulut:::pulut:::pulut:::kill, injure::: :::pulut
+v:::p:::pulk̕ʷ (p̕ulk̕ʷ):::pulk'ʷ:::sail:::pulk'w:::fold sheetlike object::: :::pulk'ʷ
+v:::p:::puɬ:::puɬ:::puɫ:::puɫ:::foam (prog. dis.)::: :::puɫ
+v:::p:::pɔs:::pos:::pɔs:::pos:::concentrate (also, 'comical' LN)::: :::pɔs
+v:::p:::pɩs-ic:::psíš:::pəs-iš:::ps-ish:::gather wood (cp. pis pl. are large)::: :::pəs-iš
 v:::p':::p̕a'ax̣ʷ:::p̕aʔx̣:::p'aʔax̣:::p'a'aqh:::heal, become well:::(includes glottal stop infix):::p'aʔax̣
-v:::p':::p̕at̕:::p̕at̕:::p'at':::p'at':::pour mushy stuff, dream (prog. dis.):::note:::p'at'
-v:::p':::p̕ats̕:::p̕ac̕:::p'ac':::p'ats':::squirt, defecate (prog. dis.):::note:::p'ac'
-v:::p':::p̕aq̕ʷ:::p̕aq̕ʷ:::p'aq'ʷ:::p'aq'w:::powder:::note:::p'aq'ʷ
-v:::p':::p̕ax̣ʷ-i'<sup>ɩ</sup>t:::p̕ax̣ʷ-iʔt:::p'ax̣ʷ-iʔt:::p'aqhw-i't:::cough:::note:::p'ax̣ʷ-iʔt
-v:::p':::p̕aɬq:::p̕aɬq:::p'aɫq:::p'aɫq:::put away, pack up:::note:::p'aɫq
-v:::p':::p̕ä'<sup>ä</sup>:::p̕eʔ:::p'ɛʔ:::p'e':::squeeze in orgasm:::note:::p'ɛʔ
-v:::p':::p̕ät:::p̕et:::p'ɛt:::p'et:::fall to ground of own weight (as grain):::note:::p'ɛt
-v:::p':::p̕ät̕:::p̕et̕:::p'ɛt':::p'et':::slip out of place:::note:::p'ɛt'
-v:::p':::p̕än:::p̕en:::p'ɛn:::p'en:::pl. long objects lie:::note:::p'ɛn
-v:::p':::p̕ät̕:::p̕et̕:::p'ɛt':::p'et':::be smooth:::note:::p'ɛt'
-v:::p':::p̕äy̕:::p̕ey̕:::p'ey':::p'e'y:::press, milk:::note:::p'ey'
-v:::p':::p̕ägw:::p̕egʷ:::p'ɛgʷ:::p'egw:::nag:::note:::p'ɛgʷ
-v:::p':::p̕ältc̕:::p̕elč̕:::p'ɛlč':::p'elch':::turn flat thing over (as body):::note:::p'ɛlč'
-v:::p':::p̕är:::p̕er:::p'ɛr(-t):::p'er(-t):::flood, be in excess, overflow:::note:::p'ɛr(-t)
-v:::p':::p̕i'<sup>ɩ</sup>:::p̕iʔ:::p'iʔ:::p'i':::crush by pressing:::note:::p'iʔ
-v:::p':::p̕its̕:::p̕ic̕:::p'ic':::p'its':::push:::note:::p'ic'
-v:::p':::p̕iy̕:::p̕iy̕:::p'iy':::p'i'y:::squeeze:::note:::p'iy'
-v:::p':::p̕ixʷ:::p̕ixʷ:::p'ixʷ(u-):::p'ikhw(u-):::be bright with own light, (- -t) be bright from reflection:::note:::p'ixʷ(u-)
-v:::p':::p̕iltc̕:::p̕ilč̕:::p'ilč':::p'ilch':::turn round objects:::note:::p'ilč'
-v:::p':::p̕iɬ:::p̕iɬ:::p'iɫ:::p'iɫ:::persons sit:::note:::p'iɫ
-v:::p':::p̕u'ut̕:::p̕uʔt:::p'uʔut':::p'u'ut':::be greasy, oily:::note:::p'uʔut'
-v:::p':::p̕um:::p̕um:::p'um:::p'um:::be mouse-colored:::note:::p'um
-v:::p':::p̕ut̕:::p̕ut̕:::p'ut':::p'ut':::come to an end (as river, road, woods):::note:::p'ut'
+v:::p':::p̕at̕:::p̕at̕:::p'at':::p'at':::pour mushy stuff, dream (prog. dis.)::: :::p'at'
+v:::p':::p̕ats̕:::p̕ac̕:::p'ac':::p'ats':::squirt, defecate (prog. dis.)::: :::p'ac'
+v:::p':::p̕aq̕ʷ:::p̕aq̕ʷ:::p'aq'ʷ:::p'aq'w:::powder::: :::p'aq'ʷ
+v:::p':::p̕ax̣ʷ-i'<sup>ɩ</sup>t:::p̕ax̣ʷ-iʔt:::p'ax̣ʷ-iʔt:::p'aqhw-i't:::cough::: :::p'ax̣ʷ-iʔt
+v:::p':::p̕aɬq:::p̕aɬq:::p'aɫq:::p'aɫq:::put away, pack up::: :::p'aɫq
+v:::p':::p̕ä'<sup>ä</sup>:::p̕eʔ:::p'ɛʔ:::p'e':::squeeze in orgasm::: :::p'ɛʔ
+v:::p':::p̕ät:::p̕et:::p'ɛt:::p'et:::fall to ground of own weight (as grain)::: :::p'ɛt
+v:::p':::p̕ät̕:::p̕et̕:::p'ɛt':::p'et':::slip out of place::: :::p'ɛt'
+v:::p':::p̕än:::p̕en:::p'ɛn:::p'en:::pl. long objects lie::: :::p'ɛn
+v:::p':::p̕ät̕:::p̕et̕:::p'ɛt':::p'et':::be smooth::: :::p'ɛt'
+v:::p':::p̕äy̕:::p̕ey̕:::p'ey':::p'e'y:::press, milk::: :::p'ey'
+v:::p':::p̕ägw:::p̕egʷ:::p'ɛgʷ:::p'egw:::nag::: :::p'ɛgʷ
+v:::p':::p̕ältc̕:::p̕elč̕:::p'ɛlč':::p'elch':::turn flat thing over (as body)::: :::p'ɛlč'
+v:::p':::p̕är:::p̕er:::p'ɛr(-t):::p'er(-t):::flood, be in excess, overflow::: :::p'ɛr(-t)
+v:::p':::p̕i'<sup>ɩ</sup>:::p̕iʔ:::p'iʔ:::p'i':::crush by pressing::: :::p'iʔ
+v:::p':::p̕its̕:::p̕ic̕:::p'ic':::p'its':::push::: :::p'ic'
+v:::p':::p̕iy̕:::p̕iy̕:::p'iy':::p'i'y:::squeeze::: :::p'iy'
+v:::p':::p̕ixʷ:::p̕ixʷ:::p'ixʷ(u-):::p'ikhw(u-):::be bright with own light, (- -t) be bright from reflection::: :::p'ixʷ(u-)
+v:::p':::p̕iltc̕:::p̕ilč̕:::p'ilč':::p'ilch':::turn round objects::: :::p'ilč'
+v:::p':::p̕iɬ:::p̕iɬ:::p'iɫ:::p'iɫ:::persons sit::: :::p'iɫ
+v:::p':::p̕u'ut̕:::p̕uʔt:::p'uʔut':::p'u'ut':::be greasy, oily::: :::p'uʔut'
+v:::p':::p̕um:::p̕um:::p'um:::p'um:::be mouse-colored::: :::p'um
+v:::p':::p̕ut̕:::p̕ut̕:::p'ut':::p'ut':::come to an end (as river, road, woods)::: :::p'ut'
 v:::p':::p̕usq̕ʷ:::p'usq'ʷ:::sail:::p'usq'w:::crumple, collapse:::unverified;  see p̕saq̕ʷ:::p'usq'ʷ
-v:::p':::p̕uy̕:::p̕uy̕:::p'uy':::p'u'y:::be wrinkled:::note:::p'uy'
-v:::p':::p̕uɬ:::p̕uɬ:::p'uɫ:::p'uɫ:::be poison ivy, use poison ivy:::note:::p'uɫ
-v:::p':::p̕ɔts̕:::p̕oc̕:::p'ɔc':::p'ots':::smash:::note:::p'ɔc'
-v:::p':::p̕ɩtc̕:::p̕ɪč̕:::p'əč'(u-):::p'ch'(u-):::shine, glitter:::note:::p'əč'(u-)
-v:::p':::p̕ɩl:::p̕ɪl:::p'əl:::p'l:::turn (as eyelid):::note:::p'əl
-v:::p':::p̕ɩp̕ɩl:::p̕ɪp̕ɪl:::p'əp'əl(u-):::p'p'l(u-):::smashed flat:::note:::p'əp'əl(u-)
-v:::p':::p̕ᴇsaq̕ʷ:::p̕saq̕ʷ:::p'əsaq'ʷ:::p'saq'w:::bone breaks:::note:::p'əsaq'ʷ
-v:::m:::may:::may:::may:::may:::predict, foresee (with -qən voice):::note:::may
-v:::m:::may:::may:::may:::may:::be muddy:::note:::may
-v:::m:::maq̕ʷ:::maq̕ʷ:::maq'ʷ:::maq'w:::pl. objects lie, pile:::note:::maq'ʷ
-v:::m:::max̣ʷ:::max̣ʷ:::max̣ʷ:::maqhw:::cover with snow:::note:::max̣ʷ
-v:::m:::mal̕:::mal̕:::mal'(-p):::ma'l(-p):::be uncomfortably warm (prog. dis.):::note:::mal'(-p)
-v:::m:::mal̕:::mal̕:::mal':::ma'l:::come to boil (prog. dis.) (same as preceding?):::note:::mal'
-v:::m:::malq̕ʷ:::malq̕ʷ:::malq'ʷ(u-):::malq'w(u-):::be spherical, make into lump:::note:::malq'ʷ(u-)
-v:::m:::maɬq:::maɬq:::maɫq:::maɫq:::heavy convex object collapses:::note:::maɫq
-v:::m:::mar-im:::marim:::mar-im:::mar-im:::treat for illness:::note:::mar-im
-v:::m:::markʷ-ä'<sup>ä</sup>:::markʷ-eʔ:::markʷ-ɛʔ:::markw-e':::season with food (as camas with blood):::note:::markʷ-ɛʔ
+v:::p':::p̕uy̕:::p̕uy̕:::p'uy':::p'u'y:::be wrinkled::: :::p'uy'
+v:::p':::p̕uɬ:::p̕uɬ:::p'uɫ:::p'uɫ:::be poison ivy, use poison ivy::: :::p'uɫ
+v:::p':::p̕ɔts̕:::p̕oc̕:::p'ɔc':::p'ots':::smash::: :::p'ɔc'
+v:::p':::p̕ɩtc̕:::p̕ɪč̕:::p'əč'(u-):::p'ch'(u-):::shine, glitter::: :::p'əč'(u-)
+v:::p':::p̕ɩl:::p̕ɪl:::p'əl:::p'l:::turn (as eyelid)::: :::p'əl
+v:::p':::p̕ɩp̕ɩl:::p̕ɪp̕ɪl:::p'əp'əl(u-):::p'p'l(u-):::smashed flat::: :::p'əp'əl(u-)
+v:::p':::p̕ᴇsaq̕ʷ:::p̕saq̕ʷ:::p'əsaq'ʷ:::p'saq'w:::bone breaks::: :::p'əsaq'ʷ
+v:::m:::may:::may:::may:::may:::predict, foresee (with -qən voice)::: :::may
+v:::m:::may:::may:::may:::may:::be muddy::: :::may
+v:::m:::maq̕ʷ:::maq̕ʷ:::maq'ʷ:::maq'w:::pl. objects lie, pile::: :::maq'ʷ
+v:::m:::max̣ʷ:::max̣ʷ:::max̣ʷ:::maqhw:::cover with snow::: :::max̣ʷ
+v:::m:::mal̕:::mal̕:::mal'(-p):::ma'l(-p):::be uncomfortably warm (prog. dis.)::: :::mal'(-p)
+v:::m:::mal̕:::mal̕:::mal':::ma'l:::come to boil (prog. dis.) (same as preceding?)::: :::mal'
+v:::m:::malq̕ʷ:::malq̕ʷ:::malq'ʷ(u-):::malq'w(u-):::be spherical, make into lump::: :::malq'ʷ(u-)
+v:::m:::maɬq:::maɬq:::maɫq:::maɫq:::heavy convex object collapses::: :::maɫq
+v:::m:::mar-im:::marim:::mar-im:::mar-im:::treat for illness::: :::mar-im
+v:::m:::markʷ-ä'<sup>ä</sup>:::markʷ-eʔ:::markʷ-ɛʔ:::markw-e':::season with food (as camas with blood)::: :::markʷ-ɛʔ
 v:::m:::mä:::doak:::mɛ:::me:::be undecided:::unverified:::mɛ
-v:::m:::mäy:::mey:::mɛy(u-):::mey(u-):::be evident that, know, -p come to know:::note:::mɛy(u-)
+v:::m:::mäy:::mey:::mɛy(u-):::mey(u-):::be evident that, know, -p come to know::: :::mɛy(u-)
 v:::m:::mäy:::doak:::mɛy:::mey:::arrange:::unverified:::mɛy
-v:::m:::mäy̕:::mey̕:::mɛy'(- -t):::me'y(- -t):::report:::note:::mɛy'(- -t)
-v:::m:::mäts:::mec:::mɛc:::mets:::be dull:::note:::mɛc
-v:::m:::mäts̕:::mec̕:::mɛc':::mets':::grease:::note:::mɛc'
-v:::m:::mätc̕:::meč̕:::mɛč':::mech':::be well-shaped (as workhorse):::note:::mɛč'
+v:::m:::mäy̕:::mey̕:::mɛy'(- -t):::me'y(- -t):::report::: :::mɛy'(- -t)
+v:::m:::mäts:::mec:::mɛc:::mets:::be dull::: :::mɛc
+v:::m:::mäts̕:::mec̕:::mɛc':::mets':::grease::: :::mɛc'
+v:::m:::mätc̕:::meč̕:::mɛč':::mech':::be well-shaped (as workhorse)::: :::mɛč'
 v:::m:::män̕:::doak:::mɛn':::me'n:::rub:::unstressed variant of min̕:::mɛn'
-v:::m:::mäxʷ:::mexʷ:::mɛxʷ(-t):::mekhw(-t):::laugh:::note:::mɛxʷ(-t)
-v:::m:::mäx̣ʷ:::mex̣ʷ:::mɛxʷ(-t):::mekhw(-t):::be in extreme agony:::note:::mɛxʷ(-t)
-v:::m:::mälk̕ʷ:::melk̕ʷ:::mɛlk'ʷ:::melk'w:::be whole, intact, complete:::note:::mɛlk'ʷ
-v:::m:::mälk̕ʷ:::melk̕ʷ:::mɛlk'ʷ:::melk'w:::curdle:::note:::mɛlk'ʷ
-v:::m:::mäɬ:::meɬ:::mɛɫ:::meɫ:::persons lie:::note:::mɛɫ
-v:::m:::mäṛʷ:::meʕʷ:::mɛʕʷ:::me(w:::smash, ruin:::note:::mɛʕʷ
+v:::m:::mäxʷ:::mexʷ:::mɛxʷ(-t):::mekhw(-t):::laugh::: :::mɛxʷ(-t)
+v:::m:::mäx̣ʷ:::mex̣ʷ:::mɛxʷ(-t):::mekhw(-t):::be in extreme agony::: :::mɛxʷ(-t)
+v:::m:::mälk̕ʷ:::melk̕ʷ:::mɛlk'ʷ:::melk'w:::be whole, intact, complete::: :::mɛlk'ʷ
+v:::m:::mälk̕ʷ:::melk̕ʷ:::mɛlk'ʷ:::melk'w:::curdle::: :::mɛlk'ʷ
+v:::m:::mäɬ:::meɬ:::mɛɫ:::meɫ:::persons lie::: :::mɛɫ
+v:::m:::mäṛʷ:::meʕʷ:::mɛʕʷ:::me(w:::smash, ruin::: :::mɛʕʷ
 v:::m:::mii:::mii:::mii:::mii:::discover, learn:::unstressed variant of mey:::mii
-v:::m:::mii:::mii(u-):::mii(u-):::mii(u-):::be evident that not:::note:::mii(u-)
-v:::m:::mi'<sup>ɩ</sup>:::miʔ:::miʔ(-t):::mi'(-t):::bore:::note:::miʔ(-t)
-v:::m:::mi'<sup>ɩ</sup>m:::miʔm:::miʔm:::mi'm:::send away, drive off:::note:::miʔm
-v:::m:::miʔt:::miʔt:::miʔt:::mi't:::be middle:::note:::miʔt
+v:::m:::mii:::mii(u-):::mii(u-):::mii(u-):::be evident that not::: :::mii(u-)
+v:::m:::mi'<sup>ɩ</sup>:::miʔ:::miʔ(-t):::mi'(-t):::bore::: :::miʔ(-t)
+v:::m:::mi'<sup>ɩ</sup>m:::miʔm:::miʔm:::mi'm:::send away, drive off::: :::miʔm
+v:::m:::miʔt:::miʔt:::miʔt:::mi't:::be middle::: :::miʔt
 v:::m:::min-s:::min-s:::min-s:::min-s:::turn face away:::unverified:::min-s
 v:::m:::min̕:::min̕:::min':::mi'n:::smear, paint:::also 'rub':::min'
 v:::m:::miy:::miy:::miy(u-):::miy(u-):::make clear, know (an idea):::unstressed variant of mey:::miy(u-)
 v:::m:::miy:::miy:::miy:::miy:::be dignified:::unverified:::miy
-v:::m:::mik̕ʷ:::mik̕ʷ:::mik'ʷ:::mik'w:::snow:::note:::mik'ʷ
-v:::m:::mixʷ:::mixʷ:::mixʷ:::mikhw:::hang in bunches (earth as it appears from sky):::note:::mixʷ
-v:::m:::milxʷ:::milxʷ:::milxʷ:::milkhw:::be naked:::note:::milxʷ
-v:::m:::mil̕xʷ:::mil̕xʷ:::mil'xʷ:::mi'lkhw:::smoke tobacco:::note:::mil'xʷ
-v:::m:::miɬ:::miɬ:::miɫ:::miɫ:::rest:::note:::miɫ
-v:::m:::mil̕:::mil̕:::mil':::mi'l:::repair:::note:::mil'
-v:::m:::mil̕:::mil̕:::mil':::mi'l:::distribute (as food at feast):::note:::mil'
-v:::m:::mil̕:::mil̕:::mil':::mi'l:::wait for:::note:::mil'
-v:::m:::mil̕:::mil̕:::mil':::mi'l:::be aimless:::note:::mil'
+v:::m:::mik̕ʷ:::mik̕ʷ:::mik'ʷ:::mik'w:::snow::: :::mik'ʷ
+v:::m:::mixʷ:::mixʷ:::mixʷ:::mikhw:::hang in bunches (earth as it appears from sky)::: :::mixʷ
+v:::m:::milxʷ:::milxʷ:::milxʷ:::milkhw:::be naked::: :::milxʷ
+v:::m:::mil̕xʷ:::mil̕xʷ:::mil'xʷ:::mi'lkhw:::smoke tobacco::: :::mil'xʷ
+v:::m:::miɬ:::miɬ:::miɫ:::miɫ:::rest::: :::miɫ
+v:::m:::mil̕:::mil̕:::mil':::mi'l:::repair::: :::mil'
+v:::m:::mil̕:::mil̕:::mil':::mi'l:::distribute (as food at feast)::: :::mil'
+v:::m:::mil̕:::mil̕:::mil':::mi'l:::wait for::: :::mil'
+v:::m:::mil̕:::mil̕:::mil':::mi'l:::be aimless::: :::mil'
 v:::m:::mim-cit:::mumšit:::mum-šit:::mum-shit:::help with burden:::unclear if -šit applicative or part of root  (see čn̕šit):::mum-šit
-v:::m:::mus:::mus:::mus:::mus:::fumble, feel about:::note:::mus
-v:::m:::mus:::mus:::mus:::mus:::four:::note:::mus
+v:::m:::mus:::mus:::mus:::mus:::fumble, feel about::: :::mus
+v:::m:::mus:::mus:::mus:::mus:::four::: :::mus
 v:::m:::mul:::doak:::mul:::mul:::be soil, dirt (prog. dis.):::expect mal or mol:::mul
 v:::m:::mul:::mul:::mul:::mul:::dip up (prog. dis.):::(R's prog. dis. not verified):::mul
-v:::m:::mᴐ'<sup>ᴐ</sup>t:::moʔt:::mɔʔt:::mo't:::smoke (prog. dis.):::note:::mɔʔt
-v:::m:::mᴐq:::moq:::mɔq (- -t):::moq:::be excitable:::note:::mɔq (- -t)
-v:::m:::mᴇntuw̕-il̕c:::mntuw̕:::məntuw'-il'š:::mntu'w-i'lsh:::arrive at destination promptly:::note:::məntuw'-il'š
-v:::m':::m̕iw:::m̕iw:::m'iw:::'miw:::cat meows:::note:::m'iw
-v:::w:::wa'ax̣:::waʔx̣:::waʔax̣:::wa'aqh:::smart (as mucus membrane or skin):::note:::waʔax̣
+v:::m:::mᴐ'<sup>ᴐ</sup>t:::moʔt:::mɔʔt:::mo't:::smoke (prog. dis.)::: :::mɔʔt
+v:::m:::mᴐq:::moq:::mɔq (- -t):::moq:::be excitable::: :::mɔq (- -t)
+v:::m:::mᴇntuw̕-il̕c:::mntuw̕:::məntuw'-il'š:::mntu'w-i'lsh:::arrive at destination promptly::: :::məntuw'-il'š
+v:::m':::m̕iw:::m̕iw:::m'iw:::'miw:::cat meows::: :::m'iw
+v:::w:::wa'ax̣:::waʔx̣:::waʔax̣:::wa'aqh:::smart (as mucus membrane or skin)::: :::waʔax̣
 v:::w:::way:::wayq:::way:::way:::bother:::unverified as way:::way
-v:::w:::wax̣ˑˑˑ:::wax̣:::wax̣:::waqh:::brook murmurs:::note:::wax̣
-v:::w:::wax̣:::wax̣:::wax̣:::waqh:::chap, (u-) having become chapped, (-t) inherently chapped, rough from chapping:::note:::wax̣
-v:::w:::wältc̕:::welč̕:::wɛlč':::welch':::roll solid object:::note:::wɛlč'
-v:::w:::wi'<sup>ɩ</sup>:::wiʔ:::wiʔ:::wi':::cry out, shout:::note:::wiʔ
-v:::w:::wi'<sup>ɩ</sup>p:::wiʔp:::wiʔp:::wi'p:::transform:::note:::wiʔp
-v:::w:::wit:::wit:::wit:::wit:::be full of maggots:::note:::wit
-v:::w:::winc:::winš:::winš:::winsh:::dance wardance:::note:::winš
-v:::w:::wic:::wiš:::wiš:::wish:::build, dwell, poles stand up:::note:::wiš
-v:::w:::wih:::wih:::wih:::wih:::dog barks:::note:::wih
-v:::w:::wụx̣ʷ:::wuxʷ:::wəx̣ʷ:::wqhw:::fire gets draft:::note:::wəx̣ʷ
+v:::w:::wax̣ˑˑˑ:::wax̣:::wax̣:::waqh:::brook murmurs::: :::wax̣
+v:::w:::wax̣:::wax̣:::wax̣:::waqh:::chap, (u-) having become chapped, (-t) inherently chapped, rough from chapping::: :::wax̣
+v:::w:::wältc̕:::welč̕:::wɛlč':::welch':::roll solid object::: :::wɛlč'
+v:::w:::wi'<sup>ɩ</sup>:::wiʔ:::wiʔ:::wi':::cry out, shout::: :::wiʔ
+v:::w:::wi'<sup>ɩ</sup>p:::wiʔp:::wiʔp:::wi'p:::transform::: :::wiʔp
+v:::w:::wit:::wit:::wit:::wit:::be full of maggots::: :::wit
+v:::w:::winc:::winš:::winš:::winsh:::dance wardance::: :::winš
+v:::w:::wic:::wiš:::wiš:::wish:::build, dwell, poles stand up::: :::wiš
+v:::w:::wih:::wih:::wih:::wih:::dog barks::: :::wih
+v:::w:::wụx̣ʷ:::wuxʷ:::wəx̣ʷ:::wqhw:::fire gets draft::: :::wəx̣ʷ
 v:::w:::wɩl̕:::wəl':::wəl':::w'l:::act unnatural, silly:::unverified glottalization, vowel:::wəl'
 v:::w:::w'ät:::w'ɛt(u-):::w'ɛt(u-):::'wet(u-):::be just outside door (probably dim. of gʷɛt[?]):::unverified:::w'ɛt(u-)
 v:::d:::daq̕:::doak:::daq':::daq':::peer through cracks:::unverified:::daq'
-v:::d:::dax̣:::dax̣:::dax̣:::daqh:::drive many, round up animals:::note:::dax̣
-v:::d:::daxʷ:::dax̣ʷ:::daxʷ(-p):::dakhw(-p):::hard object breaks in pieces:::note:::daxʷ(-p)
-v:::d:::dar:::dar:::dar:::dar:::pl. solid objects stand:::note:::dar
-v:::d:::däm:::dem:::dɛm:::dem:::be very old:::note:::dɛm
-v:::d:::däs:::des:::dɛs:::des:::camp:::note:::dɛs
-v:::d:::däx̣:::dex̣:::dɛx̣:::deqh:::round up:::note:::dɛx̣
-v:::d:::däx̣:::dex̣:::dɛx̣(-t):::deqh(-t):::pl. go, depart travel:::note:::dɛx̣(-t)
-v:::d:::däxʷ:::dex̣ʷ:::dɛx̣ʷ:::deqhw:::lower, descend, dismount:::note:::dɛx̣ʷ
-v:::d:::däl̕:::del̕:::dɛl':::de'l:::lie down like animal:::note:::dɛl'
-v:::d:::dik̕ʷ:::dik̕ʷ:::dik'ʷ:::dik'w:::cross:::note:::dik'ʷ
+v:::d:::dax̣:::dax̣:::dax̣:::daqh:::drive many, round up animals::: :::dax̣
+v:::d:::daxʷ:::dax̣ʷ:::daxʷ(-p):::dakhw(-p):::hard object breaks in pieces::: :::daxʷ(-p)
+v:::d:::dar:::dar:::dar:::dar:::pl. solid objects stand::: :::dar
+v:::d:::däm:::dem:::dɛm:::dem:::be very old::: :::dɛm
+v:::d:::däs:::des:::dɛs:::des:::camp::: :::dɛs
+v:::d:::däx̣:::dex̣:::dɛx̣:::deqh:::round up::: :::dɛx̣
+v:::d:::däx̣:::dex̣:::dɛx̣(-t):::deqh(-t):::pl. go, depart travel::: :::dɛx̣(-t)
+v:::d:::däxʷ:::dex̣ʷ:::dɛx̣ʷ:::deqhw:::lower, descend, dismount::: :::dɛx̣ʷ
+v:::d:::däl̕:::del̕:::dɛl':::de'l:::lie down like animal::: :::dɛl'
+v:::d:::dik̕ʷ:::dik̕ʷ:::dik'ʷ:::dik'w:::cross::: :::dik'ʷ
 v:::d:::dik̕ʷ-s:::dik̕ʷ:::dik'ʷ-s:::dik'w-s:::turn about in going (cross face):::this includes the face suffix =us:::dik'ʷ-s
-v:::d:::dilk̕ʷ:::dilk̕ʷ:::dilk'ʷ:::dilk'w:::cover entirely, conceal:::note:::dilk'ʷ
-v:::d:::diɬ:::diɬ:::diɫ:::diɫ:::rustle, shake:::note:::diɫ
-v:::d:::du'ukʷ:::duʔkʷ:::duʔukʷ:::du'ukw:::be stingy, grudge:::note:::duʔukʷ
-v:::d:::dul:::dul:::dul:::dul:::sing warsong:::note:::dul
-v:::d:::dul̕:::dul̕:::dul':::du'l:::run fast, pursue:::note:::dul'
-v:::d:::dᴐq̕ʷ:::doq̕ʷ:::dɔq'ʷ(-t):::doq'w(-t):::wood is rotten:::note:::dɔq'ʷ(-t)
-v:::d:::dᴐlq̕ʷ:::dolq̕ʷ:::dɔlq'ʷ:::dolq'w:::person is strong:::note:::dɔlq'ʷ
-v:::d:::dɩlim:::dlim:::dəlim:::dlim:::gallop go on fours:::note:::dəlim
-v:::t:::tam:::tam:::tam:::tam:::scorch, toast, singe (prog. dis):::note:::tam
+v:::d:::dilk̕ʷ:::dilk̕ʷ:::dilk'ʷ:::dilk'w:::cover entirely, conceal::: :::dilk'ʷ
+v:::d:::diɬ:::diɬ:::diɫ:::diɫ:::rustle, shake::: :::diɫ
+v:::d:::du'ukʷ:::duʔkʷ:::duʔukʷ:::du'ukw:::be stingy, grudge::: :::duʔukʷ
+v:::d:::dul:::dul:::dul:::dul:::sing warsong::: :::dul
+v:::d:::dul̕:::dul̕:::dul':::du'l:::run fast, pursue::: :::dul'
+v:::d:::dᴐq̕ʷ:::doq̕ʷ:::dɔq'ʷ(-t):::doq'w(-t):::wood is rotten::: :::dɔq'ʷ(-t)
+v:::d:::dᴐlq̕ʷ:::dolq̕ʷ:::dɔlq'ʷ:::dolq'w:::person is strong::: :::dɔlq'ʷ
+v:::d:::dɩlim:::dlim:::dəlim:::dlim:::gallop go on fours::: :::dəlim
+v:::t:::tam:::tam:::tam:::tam:::scorch, toast, singe (prog. dis)::: :::tam
 v:::t:::tatq:::doak:::tatq:::tatq:::hang strips of smoked fat:::unverified:::tatq
 v:::t:::tagw:::tagʷ:::taqʷ:::taqw:::buy:::typo, harmony form of √tegʷ:::taqʷ
 v:::t:::taxʷ:::doak:::taxʷ:::takhw:::twirl:::unverified:::taxʷ
-v:::t:::taq:::taq:::taq:::taq:::touch, cover with hand:::note:::taq
-v:::t:::tax̣:::tax̣:::tax̣:::taqh:::be bitter, sharp to taste:::note:::tax̣
-v:::t:::tal̕q:::tal̕q:::tal'q:::ta'lq:::touch with foot, step on, kick:::note:::tal'q
-v:::t:::tar:::tar:::tar:::tar:::untie, loosen:::note:::tar
-v:::t:::tar̕:::tar̕:::tar':::ta'r:::be laid out in trails, have trails:::note:::tar'
-v:::t:::tämxʷ:::temxʷ:::tɛmxʷ:::temkhw:::tree is rotten:::note:::tɛmxʷ
-v:::t:::täwc:::tewš:::tɛwš:::tewsh:::go across:::note:::tɛwš
+v:::t:::taq:::taq:::taq:::taq:::touch, cover with hand::: :::taq
+v:::t:::tax̣:::tax̣:::tax̣:::taqh:::be bitter, sharp to taste::: :::tax̣
+v:::t:::tal̕q:::tal̕q:::tal'q:::ta'lq:::touch with foot, step on, kick::: :::tal'q
+v:::t:::tar:::tar:::tar:::tar:::untie, loosen::: :::tar
+v:::t:::tar̕:::tar̕:::tar':::ta'r:::be laid out in trails, have trails::: :::tar'
+v:::t:::tämxʷ:::temxʷ:::tɛmxʷ:::temkhw:::tree is rotten::: :::tɛmxʷ
+v:::t:::täwc:::tewš:::tɛwš:::tewsh:::go across::: :::tɛwš
 v:::t:::täw̕š-ä(tct):::téwšečt:::tɛwš-ɛ(čt):::tewsh-e(cht):::six:::with hand suffix =ičt (stress on root):::tɛwš-ɛ(čt)
 v:::t:::täd-ɩc:::tédiš:::tɛd-əš:::ted-sh:::squirm:::with suffix -iš:::tɛd-əš
 v:::t:::tän:::ten:::tɛn:::ten:::pull line, (u-) be tight, (- -t) (clothes) fit tight, (-p) become tight (as rawhide)
-v:::t:::tän̕:::ten̕:::tɛn':::te'n:::arranged in line:::note:::tɛn'
-v:::t:::täs:::tes:::tɛs(-p):::tes(-p):::bulge:::note:::tɛs(-p)
-v:::t:::tägw:::tegʷ:::tɛgʷ:::tegw:::buy, sell:::note:::tɛgʷ
-v:::t:::tegʷ:::tɛgʷ:::tɛgʷ:::tegw:::fail to reach:::note:::tɛgʷ
-v:::t:::täkʷ:::tekʷ:::tɛkʷ:::tekw:::be stuffy (devoid of air), (u-) room is close, (-p) choke, smother:::note:::tɛkʷ
-v:::t:::täxʷ:::texʷ:::tɛxʷ:::tekhw:::add to a store:::note:::tɛxʷ
-v:::t:::täq:::teq:::tɛq:::teq:::use sharp practise, cheat:::note:::tɛq
-v:::t:::täx̣ʷ:::tex̣ʷ:::tɛx̣ʷ(u-):::teqhw(u-):::stop shaking:::note:::tɛx̣ʷ(u-)
-v:::t:::täx̣ʷ:::tex̣ʷ:::tɛx̣ʷ:::teqhw:::one stops:::note:::tɛx̣ʷ
-v:::t:::täl:::tel:::tɛl(-p):::tel(-p):::soft object breaks off:::note:::tɛl(-p)
-v:::t:::täɬ:::teɬ:::tɛɫ(u-):::teɫ(u-):::be straight, u-tɛ́ɫt, go directly:::note:::tɛɫ(u-)
-v:::t:::ti'<sup>ɩ</sup>:::tiʔ:::tiʔ:::ti':::pound, hit:::note:::tiʔ
+v:::t:::tän̕:::ten̕:::tɛn':::te'n:::arranged in line::: :::tɛn'
+v:::t:::täs:::tes:::tɛs(-p):::tes(-p):::bulge::: :::tɛs(-p)
+v:::t:::tägw:::tegʷ:::tɛgʷ:::tegw:::buy, sell::: :::tɛgʷ
+v:::t:::tegʷ:::tɛgʷ:::tɛgʷ:::tegw:::fail to reach::: :::tɛgʷ
+v:::t:::täkʷ:::tekʷ:::tɛkʷ:::tekw:::be stuffy (devoid of air), (u-) room is close, (-p) choke, smother::: :::tɛkʷ
+v:::t:::täxʷ:::texʷ:::tɛxʷ:::tekhw:::add to a store::: :::tɛxʷ
+v:::t:::täq:::teq:::tɛq:::teq:::use sharp practise, cheat::: :::tɛq
+v:::t:::täx̣ʷ:::tex̣ʷ:::tɛx̣ʷ(u-):::teqhw(u-):::stop shaking::: :::tɛx̣ʷ(u-)
+v:::t:::täx̣ʷ:::tex̣ʷ:::tɛx̣ʷ:::teqhw:::one stops::: :::tɛx̣ʷ
+v:::t:::täl:::tel:::tɛl(-p):::tel(-p):::soft object breaks off::: :::tɛl(-p)
+v:::t:::täɬ:::teɬ:::tɛɫ(u-):::teɫ(u-):::be straight, u-tɛ́ɫt, go directly::: :::tɛɫ(u-)
+v:::t:::ti'<sup>ɩ</sup>:::tiʔ:::tiʔ:::ti':::pound, hit::: :::tiʔ
 v:::t:::ti'i'<sup>ɩ</sup>:::tiʔiʔ:::tiʔi:::ti'i:::bump:::with noncontrol reduplication:::tiʔi
-v:::t:::ti'<sup>ɩ</sup>ɬ:::tiʔɬ:::tiʔɫ:::ti'ɫ:::one flies:::note:::tiʔɫ
+v:::t:::ti'<sup>ɩ</sup>ɬ:::tiʔɬ:::tiʔɫ:::ti'ɫ:::one flies::: :::tiʔɫ
 v:::t:::tim̕:::tiʔm:::tim':::ti'm:::use:::only one occurrence:::tim'
-v:::t:::tim̕:::tim̕:::tim':::ti'm:::ground is clear of snow:::note:::tim'
+v:::t:::tim̕:::tim̕:::tim':::ti'm:::ground is clear of snow::: :::tim'
 v:::t:::tiw-ä'<sup>ä</sup>:::tiweʔ:::tiw-ɛʔ:::tiw-e':::indulge:::'award':::tiw-ɛʔ
-v:::t:::tiy̕-äqʷ:::ty̕eqʷ:::tiy'-ɛqʷ(-t):::ti'y-eqw(-t):::fight:::note:::tiy'-ɛqʷ(-t)
-v:::t:::tikʷ:::tikʷ:::tikʷ:::tikw:::suspect, smell out:::note:::tikʷ
-v:::t:::tixʷ:::tixʷ:::tixʷ:::tikhw:::collect, gather, secure:::note:::tixʷ
-v:::t:::tilp:::tilp:::tilp:::tilp:::break up:::note:::tilp
-v:::t:::tiɬ:::tiɬ:::tiɫ(-t):::tiɫ(-t):::brushy objects sprawl:::note:::tiɫ(-t)
-v:::t:::tu<sup>u</sup>:::tuˑ:::tu:::tu:::crowd, swarm:::note:::tu
+v:::t:::tiy̕-äqʷ:::ty̕eqʷ:::tiy'-ɛqʷ(-t):::ti'y-eqw(-t):::fight::: :::tiy'-ɛqʷ(-t)
+v:::t:::tikʷ:::tikʷ:::tikʷ:::tikw:::suspect, smell out::: :::tikʷ
+v:::t:::tixʷ:::tixʷ:::tixʷ:::tikhw:::collect, gather, secure::: :::tixʷ
+v:::t:::tilp:::tilp:::tilp:::tilp:::break up::: :::tilp
+v:::t:::tiɬ:::tiɬ:::tiɫ(-t):::tiɫ(-t):::brushy objects sprawl::: :::tiɫ(-t)
+v:::t:::tu<sup>u</sup>:::tuˑ:::tu:::tu:::crowd, swarm::: :::tu
 v:::t:::tup:::tup:::tup:::tup:::cool:::only inchoative verified tuʔp:::tup
 v:::t:::tum:::doak:::tum:::tum:::pump, suck through tube:::unverified; only in word for 'trout'  stúmiš:::tum
-v:::t:::tuw̕:::tuw̕:::tuw':::tu'w:::stuff:::note:::tuw'
+v:::t:::tuw̕:::tuw̕:::tuw':::tu'w:::stuff::: :::tuw'
 v:::t:::tuts:::doak:::tuc(u-):::tuts(u-):::be wellfed:::unverified:::tuc(u-)
-v:::t:::tukʷ:::tukʷ:::tukʷ:::tukw:::beat, tick:::note:::tukʷ
-v:::t:::tᴐr:::tor:::tɔr:::tor:::be tough (as meat, leather):::note:::tɔr
-v:::t:::tᴐr:::tor:::tɔr:::tor:::stretch out, extend (as hand):::note:::tɔr
+v:::t:::tukʷ:::tukʷ:::tukʷ:::tukw:::beat, tick::: :::tukʷ
+v:::t:::tᴐr:::tor:::tɔr:::tor:::be tough (as meat, leather)::: :::tɔr
+v:::t:::tᴐr:::tor:::tɔr:::tor:::stretch out, extend (as hand)::: :::tɔr
 v:::t:::tᴐr-s:::tor:::tɔr-s:::tor-s:::beckon with eye:::with =us 'eye':::tɔr-s
-v:::t:::twip̕:::twip̕:::twip'(-t):::twip'(-t):::step over obstruction:::note:::twip'(-t)
+v:::t:::twip̕:::twip̕:::twip'(-t):::twip'(-t):::step over obstruction::: :::twip'(-t)
 v:::t:::twɩl-ats:::doak:::twel-ac:::twel-ats:::aim, point long thing at:::unverified:::twel-ac
-v:::t:::tqus:::doak:::tqus:::tqus:::be defeated, fire goes out:::note:::tqus
-v:::t:::tʀim:::tʕim:::tʕim(-t):::t(im(-t):::shout:::note:::tʕim(-t)
-v:::t:::tʀäh-im:::tʕeh-im:::tʕɛh-im:::t(eh-im:::give warwhoop, yell:::note:::tʕɛh-im
-v:::t':::t̕ap:::t̕ap:::t'ap:::t'ap:::shoot (prog. dis.):::note:::t'ap
-v:::t':::t̕apq:::t̕apq:::t'apq:::t'apq:::stick pinlike object in:::note:::t'apq
-v:::t':::t̕am̕:::t̕am̕:::t'am':::t'a'm:::make damp, lick, kiss:::note:::t'am'
-v:::t':::t̕as:::t̕as:::t'as:::t'as:::be thin, skinny:::note:::t'as
+v:::t:::tqus:::doak:::tqus:::tqus:::be defeated, fire goes out::: :::tqus
+v:::t:::tʀim:::tʕim:::tʕim(-t):::t(im(-t):::shout::: :::tʕim(-t)
+v:::t:::tʀäh-im:::tʕeh-im:::tʕɛh-im:::t(eh-im:::give warwhoop, yell::: :::tʕɛh-im
+v:::t':::t̕ap:::t̕ap:::t'ap:::t'ap:::shoot (prog. dis.)::: :::t'ap
+v:::t':::t̕apq:::t̕apq:::t'apq:::t'apq:::stick pinlike object in::: :::t'apq
+v:::t':::t̕am̕:::t̕am̕:::t'am':::t'a'm:::make damp, lick, kiss::: :::t'am'
+v:::t':::t̕as:::t̕as:::t'as:::t'as:::be thin, skinny::: :::t'as
 v:::t':::t̕asq:::t̕asq:::t'asq:::t'asq:::be weary with waiting:::unverified:::t'asq
-v:::t':::t̕aq:::t̕aq:::t'aq:::t'aq:::bushy stuff lies:::note:::t'aq
-v:::t':::t̕aq-t:::t̕aqt:::t'aq-t:::t'aq-t:::birds return from migration:::note:::t'aq-t
-v:::t':::t̕ax̣:::t̕ax̣:::t'ax̣(u-):::t'aqh(u-):::be swift:::note:::t'ax̣(u-)
+v:::t':::t̕aq:::t̕aq:::t'aq:::t'aq:::bushy stuff lies::: :::t'aq
+v:::t':::t̕aq-t:::t̕aqt:::t'aq-t:::t'aq-t:::birds return from migration::: :::t'aq-t
+v:::t':::t̕ax̣:::t̕ax̣:::t'ax̣(u-):::t'aqh(u-):::be swift::: :::t'ax̣(u-)
 v:::t':::t̕ax̣t.c:::t̕ax̣tš:::t'ax̣tš:::t'aqhtsh:::be unbearable:::def unverified:::t'ax̣tš
 v:::t':::t̕aqʷ:::t̕aqʷ:::t'aq'ʷ:::t'aq'w:::slap:::expect unglottalized qʷ:::t'aq'ʷ
 v:::t':::t̕aq̕ʷ-s:::t̕aq̕ʷs:::t'alq'ʷ-s:::t'alq'w-s:::egg or eye bursts:::no l; takes =us suffix (after root final s):::t'alq'ʷ-s
-v:::t':::t̕alq̕:::talq̕:::t'alq':::t'alq':::take out (as from the mouth or container):::note:::t'alq'
-v:::t':::t̕äp:::t̕ep:::t'ɛp:::t'ep:::pl. stop:::note:::t'ɛp
-v:::t':::t̕äm:::t̕em:::t'ɛm(u-,-t):::t'em(u-,-t):::be damp:::note:::t'ɛm(u-,-t)
-v:::t':::t̕äm:::t̕em:::t'ɛm:::t'em:::cut with scissors:::note:::t'ɛm
-v:::t':::t̕äm̕:::t̕em̕:::t'ɛm':::t'e'm:::cut cloth by sliding scissors through:::note:::t'ɛm'
-v:::t':::t̕äc:::t̕eš:::t'ɛš(-t):::t'esh(-t):::be sweet:::note:::t'ɛš(-t)
-v:::t':::t̕ädj:::t̕eǰ:::t'ɛǰ:::t'ej:::pour liquid:::note:::t'ɛǰ
-v:::t':::t̕äkʷ:::t̕ekʷ:::t'ɛkʷ:::t'ekw:::pl. cry out, make noise like colt:::note:::t'ɛkʷ
-v:::t':::t̕äkʷ:::t̕ekʷ:::t'ɛkʷ(u-):::t'ekw(u-):::be watertight:::note:::t'ɛkʷ(u-)
-v:::t':::t̕äkʷ-s:::t̕ekʷs:::t'ɛkʷ-s:::t'ekw-s:::bleed:::note:::t'ɛkʷ-s
-v:::t':::t̕äk̕ʷ:::t̕ek̕ʷ:::t'ɛk'ʷ:::t'ek'w:::one lies:::note:::t'ɛk'ʷ
-v:::t':::t̕äk̕ʷ:::t̕ek̕ʷ:::t'ɛk'ʷ:::t'ek'w:::be lighted:::note:::t'ɛk'ʷ
-v:::t':::t̕äxʷ:::t̕exʷ:::t'ɛxʷ:::t'ekhw:::pl. die, kill pl.:::note:::t'ɛxʷ
-v:::t':::t̕äqʷ:::t̕eqʷ:::t'ɛq'ʷ(u-):::t'eq'w(u-):::go off, explode:::note:::t'ɛq'ʷ(u-)
-v:::t':::t̕äl̕:::t̕el̕:::t'ɛl':::t'e'l:::tear, rip:::note:::t'ɛl'
-v:::t':::t̕im:::t̕im:::t'im:::t'im:::shake hands:::note:::t'im
+v:::t':::t̕alq̕:::talq̕:::t'alq':::t'alq':::take out (as from the mouth or container)::: :::t'alq'
+v:::t':::t̕äp:::t̕ep:::t'ɛp:::t'ep:::pl. stop::: :::t'ɛp
+v:::t':::t̕äm:::t̕em:::t'ɛm(u-,-t):::t'em(u-,-t):::be damp::: :::t'ɛm(u-,-t)
+v:::t':::t̕äm:::t̕em:::t'ɛm:::t'em:::cut with scissors::: :::t'ɛm
+v:::t':::t̕äm̕:::t̕em̕:::t'ɛm':::t'e'm:::cut cloth by sliding scissors through::: :::t'ɛm'
+v:::t':::t̕äc:::t̕eš:::t'ɛš(-t):::t'esh(-t):::be sweet::: :::t'ɛš(-t)
+v:::t':::t̕ädj:::t̕eǰ:::t'ɛǰ:::t'ej:::pour liquid::: :::t'ɛǰ
+v:::t':::t̕äkʷ:::t̕ekʷ:::t'ɛkʷ:::t'ekw:::pl. cry out, make noise like colt::: :::t'ɛkʷ
+v:::t':::t̕äkʷ:::t̕ekʷ:::t'ɛkʷ(u-):::t'ekw(u-):::be watertight::: :::t'ɛkʷ(u-)
+v:::t':::t̕äkʷ-s:::t̕ekʷs:::t'ɛkʷ-s:::t'ekw-s:::bleed::: :::t'ɛkʷ-s
+v:::t':::t̕äk̕ʷ:::t̕ek̕ʷ:::t'ɛk'ʷ:::t'ek'w:::one lies::: :::t'ɛk'ʷ
+v:::t':::t̕äk̕ʷ:::t̕ek̕ʷ:::t'ɛk'ʷ:::t'ek'w:::be lighted::: :::t'ɛk'ʷ
+v:::t':::t̕äxʷ:::t̕exʷ:::t'ɛxʷ:::t'ekhw:::pl. die, kill pl.::: :::t'ɛxʷ
+v:::t':::t̕äqʷ:::t̕eqʷ:::t'ɛq'ʷ(u-):::t'eq'w(u-):::go off, explode::: :::t'ɛq'ʷ(u-)
+v:::t':::t̕äl̕:::t̕el̕:::t'ɛl':::t'e'l:::tear, rip::: :::t'ɛl'
+v:::t':::t̕im:::t̕im:::t'im:::t'im:::shake hands::: :::t'im
 v:::t':::t̕im̕:::t̕im̕:::t'im':::t'i'm:::tear cloth from bolt:::unverified:::t'im'
-v:::t':::t̕id-äm:::t̕idm:::t'id-ɛm:::t'id-em:::frail, fragile:::note:::t'id-ɛm
-v:::t':::t̕its̕:::t̕ic̕:::t'ic':::t'its':::smooth by rubbing:::note:::t'ic'
-v:::t':::t̕ic:::t̕iš:::t'iš:::t'ish:::be sweetened:::note:::t'iš
-v:::t':::t̕itc:::t̕ič:::t'ič:::t'ich:::protrude:::note:::t'ič
-v:::t':::t̕itc̕:::t̕ič̕:::t'ič':::t'ich':::provide food for travel:::note:::t'ič'
-v:::t':::t̕ikʷ:::t̕ikʷ:::t'ikʷ(-t):::t'ikw(-t):::be told, (- -t) parents:::note:::t'ikʷ(-t)
-v:::t':::tixʷ-ụl:::t̕ixʷl:::t'ixʷ-əl:::t'ikhw-l:::be different, abnormal:::note:::t'ixʷ-əl
-v:::t':::t̕um:::t̕um:::t'um:::t'um:::smirk, mouth in sucking position:::note:::t'um
-v:::t':::t̕um̕:::t̕um̕:::t'um':::t'u'm:::pipelike, hollow tube:::note:::t'um'
+v:::t':::t̕id-äm:::t̕idm:::t'id-ɛm:::t'id-em:::frail, fragile::: :::t'id-ɛm
+v:::t':::t̕its̕:::t̕ic̕:::t'ic':::t'its':::smooth by rubbing::: :::t'ic'
+v:::t':::t̕ic:::t̕iš:::t'iš:::t'ish:::be sweetened::: :::t'iš
+v:::t':::t̕itc:::t̕ič:::t'ič:::t'ich:::protrude::: :::t'ič
+v:::t':::t̕itc̕:::t̕ič̕:::t'ič':::t'ich':::provide food for travel::: :::t'ič'
+v:::t':::t̕ikʷ:::t̕ikʷ:::t'ikʷ(-t):::t'ikw(-t):::be told, (- -t) parents::: :::t'ikʷ(-t)
+v:::t':::tixʷ-ụl:::t̕ixʷl:::t'ixʷ-əl:::t'ikhw-l:::be different, abnormal::: :::t'ixʷ-əl
+v:::t':::t̕um:::t̕um:::t'um:::t'um:::smirk, mouth in sucking position::: :::t'um
+v:::t':::t̕um̕:::t̕um̕:::t'um':::t'u'm:::pipelike, hollow tube::: :::t'um'
 v:::t':::t̕uw̕änt:::gʷen:::t'uw'ɛnt:::t'u'went:::be very low (dim. of gʷɛnt):::t-w̕+w̕ént --> tʔuw̕ént --> t̕uw̕ént (gʷ --> w̕ when reduplicated initially):::t'uw'ɛnt
-v:::t':::t̕uk̕ʷ:::t̕uk̕ʷ:::t'uk'ʷ:::t'uk'w:::be uneven like roots pushing up ground:::note:::t'uk'ʷ
-v:::t':::t̕uxʷ:::t̕uxʷ:::t'uxʷ(-t):::t'ukhw(-t):::one wades:::note:::t'uxʷ(-t)
-v:::t':::t̕uxʷ-ilc:::t̕uxʷ-ilš:::t'uxʷ-ilš:::t'ukhw-ilsh:::one jumps off of:::note:::t'uxʷ-ilš
-v:::t':::t̕ᴐɬ:::t̕oɬ:::t'ɔɫ:::t'oɫ:::be lumpy, sticky with mud:::note:::t'ɔɫ
-v:::t':::t̕ul̕:::t̕ul̕:::t'ul':::t'u'l:::decent, real, human, trained, refined, civilized:::note:::t'ul'
-v:::t':::t̕ul̕:::t̕ul̕:::t'ul':::t'u'l:::get acquainted, have poise, be approachable, well to do:::note:::t'ul'
-v:::t':::t̕ᴐxʷ:::t̕oxʷ:::t'ɔxʷ:::t'okhw:::fear supernatural (witch) power:::note:::t'ɔxʷ
-v:::t':::t̕ᴐqʷ:::t̕oqʷ:::t'ɔqʷ:::t'oqw:::have power, succeed in everything:::note:::t'ɔqʷ
-v:::t':::t̕ɩcsᴐ'<sup>ᴐ</sup>:::t̕išsoʔ:::t'əšsɔʔ:::t'shso':::sneeze:::note:::t'əšsɔʔ
-v:::t':::t̕ụxʷup:::t̕xʷup:::t'əxup:::t'khup:::win, earn:::note:::t'əxup
+v:::t':::t̕uk̕ʷ:::t̕uk̕ʷ:::t'uk'ʷ:::t'uk'w:::be uneven like roots pushing up ground::: :::t'uk'ʷ
+v:::t':::t̕uxʷ:::t̕uxʷ:::t'uxʷ(-t):::t'ukhw(-t):::one wades::: :::t'uxʷ(-t)
+v:::t':::t̕uxʷ-ilc:::t̕uxʷ-ilš:::t'uxʷ-ilš:::t'ukhw-ilsh:::one jumps off of::: :::t'uxʷ-ilš
+v:::t':::t̕ᴐɬ:::t̕oɬ:::t'ɔɫ:::t'oɫ:::be lumpy, sticky with mud::: :::t'ɔɫ
+v:::t':::t̕ul̕:::t̕ul̕:::t'ul':::t'u'l:::decent, real, human, trained, refined, civilized::: :::t'ul'
+v:::t':::t̕ul̕:::t̕ul̕:::t'ul':::t'u'l:::get acquainted, have poise, be approachable, well to do::: :::t'ul'
+v:::t':::t̕ᴐxʷ:::t̕oxʷ:::t'ɔxʷ:::t'okhw:::fear supernatural (witch) power::: :::t'ɔxʷ
+v:::t':::t̕ᴐqʷ:::t̕oqʷ:::t'ɔqʷ:::t'oqw:::have power, succeed in everything::: :::t'ɔqʷ
+v:::t':::t̕ɩcsᴐ'<sup>ᴐ</sup>:::t̕išsoʔ:::t'əšsɔʔ:::t'shso':::sneeze::: :::t'əšsɔʔ
+v:::t':::t̕ụxʷup:::t̕xʷup:::t'əxup:::t'khup:::win, earn::: :::t'əxup
 v:::t':::t̕ụqʷ:::doak:::t'əqʷ:::t'qw:::team up, marry:::unverified:::t'əqʷ
 v:::t':::t̕ᴇp:::doak:::t'ɛp:::t'ep:::jump aside:::unverified:::t'ɛp
-v:::t':::t̕ụk̕ʷip:::t̕k̕ʷip:::t'ək'ʷip:::t'k'wip:::start to:::note:::t'ək'ʷip
+v:::t':::t̕ụk̕ʷip:::t̕k̕ʷip:::t'ək'ʷip:::t'k'wip:::start to::: :::t'ək'ʷip
 v:::t':::t̕ụq̕ʷ:::doak:::t'əq'ʷ:::t'q'w:::put out light:::√t̕aq̕ʷs:::t'əq'ʷ
-v:::n:::nas:::nas:::nas(u-):::nas(u-):::wet:::note:::nas(u-)
-v:::n:::naq:::naq:::naq:::naq:::be satiated with food:::note:::naq
-v:::n:::naq̕:::naq̕:::naq':::naq':::organic substance is rotten:::note:::naq'
-v:::n:::naq̕ʷ:::naq̕ʷ:::naq'ʷ:::naq'w:::steal:::note:::naq'ʷ
-v:::n:::nä'<sup>ä</sup>kun:::neʔkʷun:::nɛʔkun:::ne'kun:::think:::note:::neʔkʷun
-v:::n:::näpt:::nept:::nɛpt:::nept:::pl. enter:::note:::nɛpt
-v:::n:::näk̕ʷ-ä'<sup>ä</sup>:::nek̕ʷeʔ:::nɛk'ʷ-ɛʔ:::nek'w-e':::one:::note:::nɛk'ʷ-ɛʔ
-v:::n:::näq̕:::neq̕:::nɛq'(u-):::neq'(u-):::be sticky:::note:::nɛq'(u-)
-v:::n:::när:::ner:::nɛr:::ner:::paint:::note:::nɛr
-v:::n:::niw̕:::niw̕:::niw'(-t):::ni'w(-t):::wind blows:::note:::niw'(-t)
-v:::n:::nitc:::nič:::nič:::nich:::protect:::note:::nič
-v:::n:::nitc̕:::nič̕:::nič':::nich':::cut with blade:::note:::nič'
-v:::n:::nik̕ʷ:::nik̕ʷ:::nik'ʷ:::nik'w:::be tribe:::note:::nik'ʷ
-v:::n:::nuxʷ:::nuxʷ:::nuxʷ(-t):::nukhw(-t):::frog swims:::note:::nuxʷ(-t)
-v:::n:::nᴐts:::noc:::nɔc:::nots:::tender, soft (as meat, rubber):::note:::nɔc
-v:::n':::ax̣ʷ:::n̕ax̣ʷ:::n'ax̣ʷ(-t):::'naqhw(-t):::downstream:::note:::n'ax̣ʷ(-t)
-v:::n':::n̕-id:::n̕id:::n'-id:::'n-id:::exchange, trade, pay for:::note:::n'-id
-v:::n':::n̕uɬxʷ:::n̕uɬxʷ:::n'uɫxʷ:::'nuɫkhw:::one enters:::note:::n'uɫxʷ
-v:::n':::n̕n̕ᴐy̕-ä'<sup>ä</sup>:::n̕n̕oy̕eʔ:::n'n'ɔy'-ɛʔ:::'n'no'y-e':::weak (dim):::note:::n'n'ɔy'-ɛʔ
-v:::s:::sa'ax̣:::saʔx̣:::saʔax̣:::sa'aqh:::dissolve:::note:::saʔax̣
-v:::s:::san̕:::san̕:::san'(-t):::sa'n(-t):::tame (prog, dis.), (-p) be drowsy:::note:::san'(-t)
-v:::s:::saq̕:::saq̕:::saq':::saq':::gape, split in two:::note:::saq'
-v:::s:::sax̣:::sax̣:::sax̣:::saqh:::hew, whittle:::note:::sax̣
-v:::s:::saṛʷ:::saʕʷ:::saʕʷ:::sa(w:::flow, (-p) leak:::note:::saʕʷ
-v:::s:::sättc:::setč:::sɛtč:::setch:::twist solid object (as vine, wire):::note:::sɛtč
+v:::n:::nas:::nas:::nas(u-):::nas(u-):::wet::: :::nas(u-)
+v:::n:::naq:::naq:::naq:::naq:::be satiated with food::: :::naq
+v:::n:::naq̕:::naq̕:::naq':::naq':::organic substance is rotten::: :::naq'
+v:::n:::naq̕ʷ:::naq̕ʷ:::naq'ʷ:::naq'w:::steal::: :::naq'ʷ
+v:::n:::nä'<sup>ä</sup>kun:::neʔkʷun:::nɛʔkun:::ne'kun:::think::: :::neʔkʷun
+v:::n:::näpt:::nept:::nɛpt:::nept:::pl. enter::: :::nɛpt
+v:::n:::näk̕ʷ-ä'<sup>ä</sup>:::nek̕ʷeʔ:::nɛk'ʷ-ɛʔ:::nek'w-e':::one::: :::nɛk'ʷ-ɛʔ
+v:::n:::näq̕:::neq̕:::nɛq'(u-):::neq'(u-):::be sticky::: :::nɛq'(u-)
+v:::n:::när:::ner:::nɛr:::ner:::paint::: :::nɛr
+v:::n:::niw̕:::niw̕:::niw'(-t):::ni'w(-t):::wind blows::: :::niw'(-t)
+v:::n:::nitc:::nič:::nič:::nich:::protect::: :::nič
+v:::n:::nitc̕:::nič̕:::nič':::nich':::cut with blade::: :::nič'
+v:::n:::nik̕ʷ:::nik̕ʷ:::nik'ʷ:::nik'w:::be tribe::: :::nik'ʷ
+v:::n:::nuxʷ:::nuxʷ:::nuxʷ(-t):::nukhw(-t):::frog swims::: :::nuxʷ(-t)
+v:::n:::nᴐts:::noc:::nɔc:::nots:::tender, soft (as meat, rubber)::: :::nɔc
+v:::n':::ax̣ʷ:::n̕ax̣ʷ:::n'ax̣ʷ(-t):::'naqhw(-t):::downstream::: :::n'ax̣ʷ(-t)
+v:::n':::n̕-id:::n̕id:::n'-id:::'n-id:::exchange, trade, pay for::: :::n'-id
+v:::n':::n̕uɬxʷ:::n̕uɬxʷ:::n'uɫxʷ:::'nuɫkhw:::one enters::: :::n'uɫxʷ
+v:::n':::n̕n̕ᴐy̕-ä'<sup>ä</sup>:::n̕n̕oy̕eʔ:::n'n'ɔy'-ɛʔ:::'n'no'y-e':::weak (dim)::: :::n'n'ɔy'-ɛʔ
+v:::s:::sa'ax̣:::saʔx̣:::saʔax̣:::sa'aqh:::dissolve::: :::saʔax̣
+v:::s:::san̕:::san̕:::san'(-t):::sa'n(-t):::tame (prog, dis.), (-p) be drowsy::: :::san'(-t)
+v:::s:::saq̕:::saq̕:::saq':::saq':::gape, split in two::: :::saq'
+v:::s:::sax̣:::sax̣:::sax̣:::saqh:::hew, whittle::: :::sax̣
+v:::s:::saṛʷ:::saʕʷ:::saʕʷ:::sa(w:::flow, (-p) leak::: :::saʕʷ
+v:::s:::sättc:::setč:::sɛtč:::setch:::twist solid object (as vine, wire)::: :::sɛtč
 v:::s:::sägwät:::segʷ:::sɛgʷɛt:::segwet:::who?:::√segʷ-et; also occurs alone and with -eʔ, -ɬ:::sɛgʷɛt
-v:::s:::säxʷ:::sexʷ:::sɛxʷ:::sekhw:::carry on back:::note:::sɛxʷ
-v:::s:::säxʷq:::sexʷq:::sɛxʷq:::sekhwq:::splash:::note:::sɛxʷq
-v:::s:::säx̣ʷ:::sex̣ʷ:::sɛx̣ʷ(u-,-t):::seqhw(u-,-t):::sound of cracking timbers:::note:::sɛx̣ʷ(u-,-t)
-v:::s:::säl:::sel:::sɛl:::sel:::turn, spin in eye, turn swiftly:::note:::sɛl
+v:::s:::säxʷ:::sexʷ:::sɛxʷ:::sekhw:::carry on back::: :::sɛxʷ
+v:::s:::säxʷq:::sexʷq:::sɛxʷq:::sekhwq:::splash::: :::sɛxʷq
+v:::s:::säx̣ʷ:::sex̣ʷ:::sɛx̣ʷ(u-,-t):::seqhw(u-,-t):::sound of cracking timbers::: :::sɛx̣ʷ(u-,-t)
+v:::s:::säl:::sel:::sɛl:::sel:::turn, spin in eye, turn swiftly::: :::sɛl
 v:::s:::sii-siyus:::siysiyus:::sii-siyus:::sii-siyus:::astute, canny, capable, clever, cautious, competent, diligent, discerning, enterprising, prudent, sagacious, shrewed, skillful, successful, intelligent, resourceful, adaptable:::always appears to occur reduplicated:::sii-siyus
-v:::s:::sip̕-äy̕:::sip̕ey̕:::sip'-ɛy':::sip'-e'y:::be buckskin:::note:::sip'-ɛy'
-v:::s:::sid-ɩst:::sidist:::sidəst:::sidst:::night passes, spend night:::note:::sidəst
-v:::s:::sits:::sic:::sic:::sits:::be new:::note:::sic
-v:::s:::sits̕:::sic̕:::sic':::sits':::be blanket, be blanketed:::note:::sic'
-v:::s:::siy:::siy:::siy:::siy:::exert (see sii-siyus):::note:::siy
-v:::s:::siy:::siy:::siy:::siy:::cut and gather cedarbark:::note:::siy
-v:::s:::sigw:::sigʷ:::sigʷ:::sigw:::ask for:::note:::sigʷ
-v:::s:::sixʷ:::sixʷ:::sixʷ:::sikhw:::pour solid objects or liquid:::note:::sixʷ
-v:::s:::sil:::sil:::sil:::sil:::turn, cause dizziness:::note:::sil
-v:::s:::sum̕:::sum̕:::sum':::su'm:::smell at, sniff:::note:::sum'
-v:::s:::su'ut̕:::suʔt̕:::suʔut':::su'ut':::stretch:::note:::suʔut'
-v:::s:::suk̕ʷ:::suk̕ʷ:::suk'ʷ:::suk'w:::float with current:::note:::suk'ʷ
-v:::s:::suxʷ:::suxʷ:::suxʷ(-t):::sukhw(-t):::be acquainted with, know:::note:::suxʷ(-t)
-v:::s:::suxʷ-ɩlc:::suxʷ:::suxʷ-əlš:::sukhw-lsh:::fish dives:::note:::suxʷ-əlš
-v:::s:::sul:::sul:::sul(u-):::sul(u-):::be cold (as body, stove, iron, corpse), (-t) be cold (as body, things in refrigerator):::note:::sul(u-)
+v:::s:::sip̕-äy̕:::sip̕ey̕:::sip'-ɛy':::sip'-e'y:::be buckskin::: :::sip'-ɛy'
+v:::s:::sid-ɩst:::sidist:::sidəst:::sidst:::night passes, spend night::: :::sidəst
+v:::s:::sits:::sic:::sic:::sits:::be new::: :::sic
+v:::s:::sits̕:::sic̕:::sic':::sits':::be blanket, be blanketed::: :::sic'
+v:::s:::siy:::siy:::siy:::siy:::exert (see sii-siyus)::: :::siy
+v:::s:::siy:::siy:::siy:::siy:::cut and gather cedarbark::: :::siy
+v:::s:::sigw:::sigʷ:::sigʷ:::sigw:::ask for::: :::sigʷ
+v:::s:::sixʷ:::sixʷ:::sixʷ:::sikhw:::pour solid objects or liquid::: :::sixʷ
+v:::s:::sil:::sil:::sil:::sil:::turn, cause dizziness::: :::sil
+v:::s:::sum̕:::sum̕:::sum':::su'm:::smell at, sniff::: :::sum'
+v:::s:::su'ut̕:::suʔt̕:::suʔut':::su'ut':::stretch::: :::suʔut'
+v:::s:::suk̕ʷ:::suk̕ʷ:::suk'ʷ:::suk'w:::float with current::: :::suk'ʷ
+v:::s:::suxʷ:::suxʷ:::suxʷ(-t):::sukhw(-t):::be acquainted with, know::: :::suxʷ(-t)
+v:::s:::suxʷ-ɩlc:::suxʷ:::suxʷ-əlš:::sukhw-lsh:::fish dives::: :::suxʷ-əlš
+v:::s:::sul:::sul:::sul(u-):::sul(u-):::be cold (as body, stove, iron, corpse), (-t) be cold (as body, things in refrigerator)::: :::sul(u-)
 v:::s:::sɩlup:::sil:::səlup:::slup:::spin of itself, set self spinning:::sfx -up nonvolitional:::səlup
 v:::s:::sɩls-us:::doak:::səls-us:::sls-us:::houses blow down:::unconfirmed vowel:::səls-us
-v:::s:::swi'<sup>ɩ</sup>:::swiʔ:::swiʔ:::swi':::be handsome, beautiful (of persons only):::note:::swiʔ
-v:::s:::slip̕:::slip̕:::slip':::slip':::be wood:::note:::slip'
-v:::c/ts:::tsas:::cas:::cas(-t):::tsas(-t):::be long slender, be fine:::note:::cas(-t)
-v:::c/ts:::tsap̕:::cap̕:::cap':::tsap':::girls 'snap' eyes to show contempt:::note:::cap'
-v:::c/ts:::tsaq:::caq:::caq:::tsaq:::solid object stands upright:::note:::caq
-v:::c/ts:::tsaqip:::caqíp:::caqip:::tsaqip:::follow:::note:::caqip
-v:::c/ts:::tsaqʷ:::caqʷ:::caqʷ:::tsaqw:::long object slips into hollow object:::note:::caqʷ
-v:::c/ts:::tsax̣ʷ:::cax̣ʷ:::cax̣ʷ:::tsaqhw:::increase as by saving:::note:::cax̣ʷ
+v:::s:::swi'<sup>ɩ</sup>:::swiʔ:::swiʔ:::swi':::be handsome, beautiful (of persons only)::: :::swiʔ
+v:::s:::slip̕:::slip̕:::slip':::slip':::be wood::: :::slip'
+v:::c/ts:::tsas:::cas:::cas(-t):::tsas(-t):::be long slender, be fine::: :::cas(-t)
+v:::c/ts:::tsap̕:::cap̕:::cap':::tsap':::girls 'snap' eyes to show contempt::: :::cap'
+v:::c/ts:::tsaq:::caq:::caq:::tsaq:::solid object stands upright::: :::caq
+v:::c/ts:::tsaqip:::caqíp:::caqip:::tsaqip:::follow::: :::caqip
+v:::c/ts:::tsaqʷ:::caqʷ:::caqʷ:::tsaqw:::long object slips into hollow object::: :::caqʷ
+v:::c/ts:::tsax̣ʷ:::cax̣ʷ:::cax̣ʷ:::tsaqhw:::increase as by saving::: :::cax̣ʷ
 v:::c/ts:::tsalxʷ or tsalx̣ʷ:::calxʷ, calx̣ʷ:::calxʷ (calx̣ʷ):::tsalkhw:::claw, dig, dig claws in:::note that Reichard uses ts̕alx̣ʷ, tsalx̣ʷ, tsalxʷ:::calxʷ (calx̣ʷ)
-v:::c/ts:::tsaʀ:::caʕ:::caʕ:::tsa(:::scream, shriek with pain:::note:::caʕ
-v:::c/ts:::tsaṛʷ:::caʕʷ:::caʕʷ:::tsa(w:::fringe:::note:::caʕʷ
-v:::c/ts:::tsätxʷ:::cetxʷ:::cɛtxʷ:::tsetkhw:::be house:::note:::cɛtxʷ
-v:::c/ts:::tsätc:::ceč:::cɛč:::tsech:::thunder strikes:::note:::cɛč
-v:::c/ts:::tsägw:::cegʷ:::cɛgʷ:::tsegw:::be feather:::note:::cɛgʷ
-v:::c/ts:::tsägw:::cegʷ:::cɛgʷ:::tsegw:::behave, have character:::note:::cɛgʷ
-v:::c/ts:::tsäkʷ:::cek̕ʷ:::cɛk'ʷ:::tsek'w:::drag, pull:::note:::cɛk'ʷ
-v:::c/ts:::tsäxʷ:::cexʷ:::cɛxʷ:::tsekhw:::pet:::note:::cɛxʷ
-v:::c/ts:::tsä'<sup>ä</sup>xʷ:::ceʔxʷ:::cɛʔxʷ:::tse'khw:::caress:::note:::cɛʔxʷ
-v:::c/ts:::tsäxʷ:::cexʷ:::cɛxʷ:::tsekhw:::peel bark off twig:::note:::cɛxʷ
-v:::c/ts:::tsäqʷ:::ceqʷ:::cɛqʷ:::tseqw:::be bright pink (color of tamarack wood):::note:::cɛqʷ
-v:::c/ts:::tsäls:::cels:::cɛls:::tsels:::sound guilty:::note:::cɛls
-v:::c/ts:::tsi'<sup>ɩ</sup>:::ciʔ:::ciʔ:::tsi':::there near second person:::note:::ciʔ
-v:::c/ts:::tsi'<sup>ɩ</sup>xʷ:::ciʔxʷ:::ciʔxʷ:::tsi'khw:::pl. wade, enter water:::note:::ciʔxʷ
-v:::c/ts:::tsiw̕:::ciw̕:::ciw':::tsi'w:::be youngest child:::note:::ciw'
-v:::c/ts:::tsis:::cis:::cis:::tsis:::be made long and slender:::note:::cis
-v:::c/ts:::tsic:::ciš:::ciš:::tsish:::be long, tall:::note:::ciš
-v:::c/ts:::tsic:::ciš:::ciš(u-):::tsish(u-):::be heated:::note:::ciš(u-)
-v:::c/ts:::tsikʷ:::cikʷ:::cik'ʷ:::tsik'w:::cause blurry look:::note:::cik'ʷ
-v:::c/ts:::tsil:::cil:::cil:::tsil:::five:::note:::cil
-v:::c/ts:::tsih:::cih:::cih:::tsih:::be next to move:::note:::cih
-v:::c/ts:::tsum:::cum:::cum:::tsum:::be surfeited with fat:::note:::cum
-v:::c/ts:::tsuw̕:::cuw̕:::cuw':::tsu'w:::punch:::note:::cuw'
-v:::c/ts:::tsun:::cun:::cun:::tsun:::point, show:::note:::cun
-v:::c/ts:::tsun-tct:::cun-čt:::cun-čt:::tsun-cht:::seven:::note:::cun-čt
-v:::c/ts:::tsus:::cus:::cus:::tsus:::snake rattles:::note:::cus
-v:::c/ts:::tsuy̕:::cuy̕̕:::cuy'(u-, -t):::tsu'y(u-, -t):::be chilly, make gooseflesh:::note:::cuy'(u-, -t)
-v:::c/ts:::tsᴐ'<sup>ᴐ</sup>t:::coʔt:::cɔʔt:::tso't:::sob (prog. dis.):::note:::cɔʔt
-v:::c/ts:::tsɩtsä:::cceʔ:::cəcɛ:::tstse:::leave alone, unharmed:::note:::cəcɛ:
-v:::c/ts:::tsɩtsäm̕ä'<sup>ä</sup>:::ccémeʔ:::cəcɛm'-ɛʔ:::tstse'm-e':::pl. are small:::note:::cəcɛm'-ɛʔ
-v:::c/ts:::tsụkʷigw:::ckʷigʷt:::cəkʷigʷ(-t):::tskwigw(-t):::see dimly, be indistinct to sight:::note:::cəkʷigʷ(-t)
+v:::c/ts:::tsaʀ:::caʕ:::caʕ:::tsa(:::scream, shriek with pain::: :::caʕ
+v:::c/ts:::tsaṛʷ:::caʕʷ:::caʕʷ:::tsa(w:::fringe::: :::caʕʷ
+v:::c/ts:::tsätxʷ:::cetxʷ:::cɛtxʷ:::tsetkhw:::be house::: :::cɛtxʷ
+v:::c/ts:::tsätc:::ceč:::cɛč:::tsech:::thunder strikes::: :::cɛč
+v:::c/ts:::tsägw:::cegʷ:::cɛgʷ:::tsegw:::be feather::: :::cɛgʷ
+v:::c/ts:::tsägw:::cegʷ:::cɛgʷ:::tsegw:::behave, have character::: :::cɛgʷ
+v:::c/ts:::tsäkʷ:::cek̕ʷ:::cɛk'ʷ:::tsek'w:::drag, pull::: :::cɛk'ʷ
+v:::c/ts:::tsäxʷ:::cexʷ:::cɛxʷ:::tsekhw:::pet::: :::cɛxʷ
+v:::c/ts:::tsä'<sup>ä</sup>xʷ:::ceʔxʷ:::cɛʔxʷ:::tse'khw:::caress::: :::cɛʔxʷ
+v:::c/ts:::tsäxʷ:::cexʷ:::cɛxʷ:::tsekhw:::peel bark off twig::: :::cɛxʷ
+v:::c/ts:::tsäqʷ:::ceqʷ:::cɛqʷ:::tseqw:::be bright pink (color of tamarack wood)::: :::cɛqʷ
+v:::c/ts:::tsäls:::cels:::cɛls:::tsels:::sound guilty::: :::cɛls
+v:::c/ts:::tsi'<sup>ɩ</sup>:::ciʔ:::ciʔ:::tsi':::there near second person::: :::ciʔ
+v:::c/ts:::tsi'<sup>ɩ</sup>xʷ:::ciʔxʷ:::ciʔxʷ:::tsi'khw:::pl. wade, enter water::: :::ciʔxʷ
+v:::c/ts:::tsiw̕:::ciw̕:::ciw':::tsi'w:::be youngest child::: :::ciw'
+v:::c/ts:::tsis:::cis:::cis:::tsis:::be made long and slender::: :::cis
+v:::c/ts:::tsic:::ciš:::ciš:::tsish:::be long, tall::: :::ciš
+v:::c/ts:::tsic:::ciš:::ciš(u-):::tsish(u-):::be heated::: :::ciš(u-)
+v:::c/ts:::tsikʷ:::cikʷ:::cik'ʷ:::tsik'w:::cause blurry look::: :::cik'ʷ
+v:::c/ts:::tsil:::cil:::cil:::tsil:::five::: :::cil
+v:::c/ts:::tsih:::cih:::cih:::tsih:::be next to move::: :::cih
+v:::c/ts:::tsum:::cum:::cum:::tsum:::be surfeited with fat::: :::cum
+v:::c/ts:::tsuw̕:::cuw̕:::cuw':::tsu'w:::punch::: :::cuw'
+v:::c/ts:::tsun:::cun:::cun:::tsun:::point, show::: :::cun
+v:::c/ts:::tsun-tct:::cun-čt:::cun-čt:::tsun-cht:::seven::: :::cun-čt
+v:::c/ts:::tsus:::cus:::cus:::tsus:::snake rattles::: :::cus
+v:::c/ts:::tsuy̕:::cuy̕̕:::cuy'(u-, -t):::tsu'y(u-, -t):::be chilly, make gooseflesh::: :::cuy'(u-, -t)
+v:::c/ts:::tsᴐ'<sup>ᴐ</sup>t:::coʔt:::cɔʔt:::tso't:::sob (prog. dis.)::: :::cɔʔt
+v:::c/ts:::tsɩtsä:::cceʔ:::cəcɛ:::tstse:::leave alone, unharmed::: :::cəcɛ:
+v:::c/ts:::tsɩtsäm̕ä'<sup>ä</sup>:::ccémeʔ:::cəcɛm'-ɛʔ:::tstse'm-e':::pl. are small::: :::cəcɛm'-ɛʔ
+v:::c/ts:::tsụkʷigw:::ckʷigʷt:::cəkʷigʷ(-t):::tskwigw(-t):::see dimly, be indistinct to sight::: :::cəkʷigʷ(-t)
 v:::c'/ts':::ts̕ap̕q̕:::c̕ap̕aq̕:::c'ap'q':::ts'ap'q':::adhere, stick to (as glue):::evidence of stress on either vowel, i.e., c̕áp̕q̕ and c̕əp̕áq̕ both occur:::c'ap'q'
-v:::c'/ts':::ts̕am:::c̕am:::c'am:::ts'am:::be nearly pointed (as football, or lemon):::note:::c'am
-v:::c'/ts':::ts̕aw:::c̕aw:::c'aw(u-):::ts'aw(u-):::be dry, boring, washed out (lit. soaked out):::note:::c'aw(u-)
-v:::c'/ts':::ts̕aw̕:::c̕aw̕:::c'aw':::ts'a'w:::wash:::note:::c'aw'
-v:::c'/ts':::ts̕aw̕q:::c̕aw̕q:::c'aw'q:::ts'a'wq:::pull out solid object (as nail out of board):::note:::c'aw'q
-v:::c'/ts':::ts̕aq̕:::c̕aq̕:::c'aq':::ts'aq':::be bunched, clumped:::note:::c'aq'
-v:::c'/ts':::ts̕ax̣ʷ:::c̕ax̣ʷ:::c'ax̣ʷ:::ts'aqhw:::choose:::note:::c'ax̣ʷ
-v:::c'/ts':::ts̕ax̣ʷ:::c̕ax̣ʷ:::c'ax̣ʷ:::ts'aqhw:::promise:::note:::c'ax̣ʷ
+v:::c'/ts':::ts̕am:::c̕am:::c'am:::ts'am:::be nearly pointed (as football, or lemon)::: :::c'am
+v:::c'/ts':::ts̕aw:::c̕aw:::c'aw(u-):::ts'aw(u-):::be dry, boring, washed out (lit. soaked out)::: :::c'aw(u-)
+v:::c'/ts':::ts̕aw̕:::c̕aw̕:::c'aw':::ts'a'w:::wash::: :::c'aw'
+v:::c'/ts':::ts̕aw̕q:::c̕aw̕q:::c'aw'q:::ts'a'wq:::pull out solid object (as nail out of board)::: :::c'aw'q
+v:::c'/ts':::ts̕aq̕:::c̕aq̕:::c'aq':::ts'aq':::be bunched, clumped::: :::c'aq'
+v:::c'/ts':::ts̕ax̣ʷ:::c̕ax̣ʷ:::c'ax̣ʷ:::ts'aqhw:::choose::: :::c'ax̣ʷ
+v:::c'/ts':::ts̕ax̣ʷ:::c̕ax̣ʷ:::c'ax̣ʷ:::ts'aqhw:::promise::: :::c'ax̣ʷ
 v:::c'/ts':::ts̕al-alqʷ:::c̕əlálqʷ:::c'al-alqʷ:::ts'al-alqw:::play stickgame (c'al one person stands; -alqʷ long object):::√c̕el=alqʷ:::c'al-alqʷ
-v:::c'/ts':::ts̕alx̣ʷ:::c̕alx̣ʷ:::c'alx̣ʷ:::ts'alqhw:::claw, dig claws in:::note:::c'alx̣ʷ
-v:::c'/ts':::ts̕ar:::c̕ar:::c'ar:::ts'ar:::be ill, hurt, ache:::note:::c'ar
-v:::c'/ts':::ts̕ar:::c̕ar:::c'ar(-t):::ts'ar(-t):::feel cold to touch (stove, ice):::note:::c'ar(-t)
-v:::c'/ts':::ts̕äp̕:::c̕ep̕:::c'ɛp':::ts'ep':::lightproof:::note:::c'ɛp'
-v:::c'/ts':::ts̕äs:::c̕es:::c'ɛs:::ts'es:::collect by pecking, salvage:::note:::c'ɛs
-v:::c'/ts':::ts̕äsp:::c̕esp:::c'ɛsp:::ts'esp:::annihilate, destroy, consume, use up:::note:::c'ɛsp
-v:::c'/ts':::ts̕ätc:::c̕eč:::c'ɛč:::ts'ech:::count, number:::note:::c'ɛč
-v:::c'/ts':::ts̕äk̕ʷ:::c̕ek̕ʷ:::c'ɛk'ʷ(u-):::ts'ek'w(u-):::be stiff (as bones):::note:::c'ɛk'ʷ(u-)
-v:::c'/ts':::ts̕äx̣:::c̕ex̣:::c'ɛx̣:::ts'eqh:::fry:::note:::c'ɛx̣
-v:::c'/ts':::ts̕äqʷ:::c̕eqʷ:::c'ɛqʷ:::ts'eqw:::butcher:::note:::c'ɛqʷ
-v:::c'/ts':::ts̕äx̣ʷ:::c̕ex̣ʷ:::c'ɛx̣ʷ:::ts'eqhw:::spark:::note:::c'ɛx̣ʷ
-v:::c'/ts':::ts̕äl:::c̕el:::c'ɛl:::ts'el:::one stands:::note:::c'ɛl
-v:::c'/ts':::ts̕äl̕:::c̕el̕:::c'ɛl':::ts'e'l:::pl. long objects project, stand up:::note:::c'ɛl'
-v:::c'/ts':::ts̕äl̕:::c̕el̕:::c'ɛl'(u-):::ts'e'l(u-):::fear fierce one, (- -t) one is fierce:::note:::c'ɛl'(u-)
-v:::c'/ts':::ts̕ip̕:::c̕ip:::c'ip':::ts'ip':::pinch fine:::note:::c'ip'
-v:::c'/ts':::reichard:::c̕im:::c'im:::ts'im:::grab handful:::note:::c'im
-v:::c'/ts':::ts̕its̕:::c̕ic̕:::c'ic':::ts'its':::pinch skin together:::note:::c'ic'
-v:::c'/ts':::ts̕itc:::c̕ič:::c'ič:::ts'ich:::be prickly, (u-) be rough like file:::note:::c'ič
-v:::c'/ts':::ts̕iy̕:::c̕iy̕:::c'iy':::ts'i'y:::be right side:::note:::c'iy'
-v:::c'/ts':::ts̕ikʷ-ä'<sup>ä</sup>:::c̕íkʷeʔ:::c'ikʷ-ɛʔ:::ts'ikw-e':::be left side:::note:::c'ikʷ-ɛʔ
-v:::c'/ts':::ts̕ixʷ:::c̕ixʷ:::c'ixʷ:::ts'ikhw:::prepare chips by peeling and tying:::note:::c'ixʷ
-v:::c'/ts':::ts̕iɬ:::c̕iɬ:::c'iɫ(u-):::ts'iɫ(u-):::weather is cool:::note:::c'iɫ(u-)
-v:::c'/ts':::ts̕il̕:::c̕il̕:::c'il':::ts'i'l:::be outline, shadow:::note:::c'il'
-v:::c'/ts':::ts̕u'um:::c̕uʔm:::c'uʔum:::ts'u'um:::cry, weep:::note:::c'uʔum
-v:::c'/ts':::ts̕ul̕:::c̕ul̕:::c'ul':::ts'u'l:::break sad news, report death:::note:::c'ul'
-v:::c'/ts':::ts̕ᴐm̕:::c̕om̕:::c'ɔm':::ts'o'm:::suck on solid object:::note:::c'ɔm'
-v:::c'/ts':::ts̕ᴐr:::c̕or:::c'ɔr:::ts'or:::be sour:::note:::c'ɔr
+v:::c'/ts':::ts̕alx̣ʷ:::c̕alx̣ʷ:::c'alx̣ʷ:::ts'alqhw:::claw, dig claws in::: :::c'alx̣ʷ
+v:::c'/ts':::ts̕ar:::c̕ar:::c'ar:::ts'ar:::be ill, hurt, ache::: :::c'ar
+v:::c'/ts':::ts̕ar:::c̕ar:::c'ar(-t):::ts'ar(-t):::feel cold to touch (stove, ice)::: :::c'ar(-t)
+v:::c'/ts':::ts̕äp̕:::c̕ep̕:::c'ɛp':::ts'ep':::lightproof::: :::c'ɛp'
+v:::c'/ts':::ts̕äs:::c̕es:::c'ɛs:::ts'es:::collect by pecking, salvage::: :::c'ɛs
+v:::c'/ts':::ts̕äsp:::c̕esp:::c'ɛsp:::ts'esp:::annihilate, destroy, consume, use up::: :::c'ɛsp
+v:::c'/ts':::ts̕ätc:::c̕eč:::c'ɛč:::ts'ech:::count, number::: :::c'ɛč
+v:::c'/ts':::ts̕äk̕ʷ:::c̕ek̕ʷ:::c'ɛk'ʷ(u-):::ts'ek'w(u-):::be stiff (as bones)::: :::c'ɛk'ʷ(u-)
+v:::c'/ts':::ts̕äx̣:::c̕ex̣:::c'ɛx̣:::ts'eqh:::fry::: :::c'ɛx̣
+v:::c'/ts':::ts̕äqʷ:::c̕eqʷ:::c'ɛqʷ:::ts'eqw:::butcher::: :::c'ɛqʷ
+v:::c'/ts':::ts̕äx̣ʷ:::c̕ex̣ʷ:::c'ɛx̣ʷ:::ts'eqhw:::spark::: :::c'ɛx̣ʷ
+v:::c'/ts':::ts̕äl:::c̕el:::c'ɛl:::ts'el:::one stands::: :::c'ɛl
+v:::c'/ts':::ts̕äl̕:::c̕el̕:::c'ɛl':::ts'e'l:::pl. long objects project, stand up::: :::c'ɛl'
+v:::c'/ts':::ts̕äl̕:::c̕el̕:::c'ɛl'(u-):::ts'e'l(u-):::fear fierce one, (- -t) one is fierce::: :::c'ɛl'(u-)
+v:::c'/ts':::ts̕ip̕:::c̕ip:::c'ip':::ts'ip':::pinch fine::: :::c'ip'
+v:::c'/ts':::reichard:::c̕im:::c'im:::ts'im:::grab handful::: :::c'im
+v:::c'/ts':::ts̕its̕:::c̕ic̕:::c'ic':::ts'its':::pinch skin together::: :::c'ic'
+v:::c'/ts':::ts̕itc:::c̕ič:::c'ič:::ts'ich:::be prickly, (u-) be rough like file::: :::c'ič
+v:::c'/ts':::ts̕iy̕:::c̕iy̕:::c'iy':::ts'i'y:::be right side::: :::c'iy'
+v:::c'/ts':::ts̕ikʷ-ä'<sup>ä</sup>:::c̕íkʷeʔ:::c'ikʷ-ɛʔ:::ts'ikw-e':::be left side::: :::c'ikʷ-ɛʔ
+v:::c'/ts':::ts̕ixʷ:::c̕ixʷ:::c'ixʷ:::ts'ikhw:::prepare chips by peeling and tying::: :::c'ixʷ
+v:::c'/ts':::ts̕iɬ:::c̕iɬ:::c'iɫ(u-):::ts'iɫ(u-):::weather is cool::: :::c'iɫ(u-)
+v:::c'/ts':::ts̕il̕:::c̕il̕:::c'il':::ts'i'l:::be outline, shadow::: :::c'il'
+v:::c'/ts':::ts̕u'um:::c̕uʔm:::c'uʔum:::ts'u'um:::cry, weep::: :::c'uʔum
+v:::c'/ts':::ts̕ul̕:::c̕ul̕:::c'ul':::ts'u'l:::break sad news, report death::: :::c'ul'
+v:::c'/ts':::ts̕ᴐm̕:::c̕om̕:::c'ɔm':::ts'o'm:::suck on solid object::: :::c'ɔm'
+v:::c'/ts':::ts̕ᴐr:::c̕or:::c'ɔr:::ts'or:::be sour::: :::c'ɔr
 v:::c'/ts':::ts̕ᴇm:::[no root]:::c'əm:::ts'm:::press make tight (cp. c'am):::the root is √yac̕ ; apparently GAR mis analyzed words such as syačyác̕mšn   brakeman   as having the root c̕əm rather than √yac̕:::c'əm
-v:::c'/ts':::ts̕ụkʷin:::c̕kʷin:::c'əkʷin:::ts'kwin:::run:::note:::c'əkʷin
+v:::c'/ts':::ts̕ụkʷin:::c̕kʷin:::c'əkʷin:::ts'kwin:::run::: :::c'əkʷin
 v:::c'/ts':::ts̕uq̕un:::c̕uq̕ʷun:::c'uq'un:::ts'uq'un:::pronounce:::sc̕əq̕ʷc̕úq̕ʷn̕ catechism instruction  ; c̕əq̕ʷúnc he pronounced it:::c'uq'un
-v:::š/sh:::cap:::šap:::šap:::shap:::tear meat from bone:::note:::šap
+v:::š/sh:::cap:::šap:::šap:::shap:::tear meat from bone::: :::šap
 v:::š/sh:::cacagw:::šagʷ:::šašagʷ(-t):::shashagw(-t):::be sharp:::ššágʷt   little bit sharp  ;  šášəgʷt   sharp:::šašagʷ(-t)
-v:::š/sh:::car:::šar:::šar:::shar:::use no energy, (u-) be inefficient, (-t) be idle:::note:::šar
-v:::š/sh:::car:::šar:::šar:::shar:::be difficult, disobedient, annoying:::note:::šar
-v:::š/sh:::car:::šar:::šar:::shar:::one hangs:::note:::šar
-v:::š/sh:::cartc:::šarč:::šarč:::sharch:::be troublesome:::note:::šarč
-v:::š/sh:::cäp:::šep:::šɛp:::shep:::discriminate, select, sift:::note:::šɛp
-v:::š/sh:::cäm:::šem:::šɛm:::shem:::be in between:::note:::šɛm
-v:::š/sh:::cät:::šet:::šɛt:::shet:::tease:::note:::šɛt
-v:::š/sh:::cät̕:::šet̕:::šɛt':::shet':::beat in contest, level:::note:::šɛt'
-v:::š/sh:::cät̕:::šet̕:::šɛt':::shet':::one long object projects:::note:::šɛt'
-v:::š/sh:::cät̕:::šet̕:::šɛt':::shet':::take care of:::note:::šɛt'
-v:::š/sh:::cät̕:::šet̕:::šɛt':::shet':::surround by enemy:::note:::šɛt'
-v:::š/sh:::cän:::šen:::šɛn:::shen:::labor:::note:::šɛn
-v:::š/sh:::reichard:::šen̕:::šɛn':::she'n:::one flat object lies:::note:::šɛn'
-v:::š/sh:::cäs:::šes:::šɛs:::shes:::be doubtful about, ignorant of, refuse to believe in:::note:::šɛs
-v:::š/sh:::cäts:::šec:::šɛc:::shets:::dig in ground:::note:::šɛc
-v:::š/sh:::cäts̕:::šec̕:::šɛc':::shets':::wait:::note:::šɛc'
-v:::š/sh:::cäts̕:::šec̕:::šɛc'(u-):::shets'(u-):::be firm, solid, permanent:::note:::šɛc'(u-)
-v:::š/sh:::cätc̕:::šeč̕:::šɛč':::shech':::wait (perhaps the last three are the same):::note:::šɛč'
-v:::š/sh:::cäl:::šel:::šɛl:::shel:::chop, split:::note:::šɛl
+v:::š/sh:::car:::šar:::šar:::shar:::use no energy, (u-) be inefficient, (-t) be idle::: :::šar
+v:::š/sh:::car:::šar:::šar:::shar:::be difficult, disobedient, annoying::: :::šar
+v:::š/sh:::car:::šar:::šar:::shar:::one hangs::: :::šar
+v:::š/sh:::cartc:::šarč:::šarč:::sharch:::be troublesome::: :::šarč
+v:::š/sh:::cäp:::šep:::šɛp:::shep:::discriminate, select, sift::: :::šɛp
+v:::š/sh:::cäm:::šem:::šɛm:::shem:::be in between::: :::šɛm
+v:::š/sh:::cät:::šet:::šɛt:::shet:::tease::: :::šɛt
+v:::š/sh:::cät̕:::šet̕:::šɛt':::shet':::beat in contest, level::: :::šɛt'
+v:::š/sh:::cät̕:::šet̕:::šɛt':::shet':::one long object projects::: :::šɛt'
+v:::š/sh:::cät̕:::šet̕:::šɛt':::shet':::take care of::: :::šɛt'
+v:::š/sh:::cät̕:::šet̕:::šɛt':::shet':::surround by enemy::: :::šɛt'
+v:::š/sh:::cän:::šen:::šɛn:::shen:::labor::: :::šɛn
+v:::š/sh:::reichard:::šen̕:::šɛn':::she'n:::one flat object lies::: :::šɛn'
+v:::š/sh:::cäs:::šes:::šɛs:::shes:::be doubtful about, ignorant of, refuse to believe in::: :::šɛs
+v:::š/sh:::cäts:::šec:::šɛc:::shets:::dig in ground::: :::šɛc
+v:::š/sh:::cäts̕:::šec̕:::šɛc':::shets':::wait::: :::šɛc'
+v:::š/sh:::cäts̕:::šec̕:::šɛc'(u-):::shets'(u-):::be firm, solid, permanent::: :::šɛc'(u-)
+v:::š/sh:::cätc̕:::šeč̕:::šɛč':::shech':::wait (perhaps the last three are the same)::: :::šɛč'
+v:::š/sh:::cäl:::šel:::šɛl:::shel:::chop, split::: :::šɛl
 v:::š/sh:::cältc:::šel; šelč:::šɛlč:::shelch:::move in a circle:::k̕ʷey kʷu šell 'you're still going in circles':::šɛlč
-v:::š/sh:::ci'<sup>ɩ</sup>:::šiʔ:::šiʔ:::shi':::be fastidious:::note:::šiʔ
-v:::š/sh:::ci'<sup>ɩ</sup>t:::šiʔt:::šiʔt:::shi't:::be first, oldest:::note:::šiʔt
-v:::š/sh:::cip:::šip:::šip(-t):::ship(-t):::be slow, deliberate in action:::note:::šip(-t)
-v:::š/sh:::cip:::šip:::šip:::ship:::complete task:::note:::šip
-v:::š/sh:::cip:::šip:::šip:::ship:::possess without interference:::note:::šip
-v:::š/sh:::cim̕:::šim̕:::šim':::shi'm:::benefit:::note:::šim'
-v:::š/sh:::ciw̕:::šiw̕:::šiw':::shi'w:::be girl:::note:::šiw'
-v:::š/sh:::ciɬ:::šiɬ:::šiɫ(u-):::shiɫ(u-):::fit, be exact, correct:::note:::šiɫ(u-)
-v:::š/sh:::cɩcɩl̕:::[no root]:::šəšəl'(u-):::shsh'l(u-):::be very fine:::note:::šəšəl'(u-)
-v:::j:::jar̕:::ǰar̕:::ǰar':::ja'r:::be firm, strong:::note:::ǰar'
-v:::j:::djäm:::ǰem:::ǰɛm:::jem:::pin, brace:::note:::ǰɛm
-v:::j:::djäy̕djiy̕:::ǰey̕:::ǰɛy'ǰiy'(-t):::je'yji'y(-t):::be ugly, homely, unsightly:::note:::ǰɛy'ǰiy'(-t)
-v:::j:::djax̣:::ǰex̣:::ǰax̣:::jaqh:::mark by scratching:::note:::ǰax̣
-v:::j:::tcastq:::častq:::častq:::chastq:::dig camas:::note:::častq
-v:::j:::tcăy:::čay:::čay(u-):::chay(u-):::one is enduring, solid form:::note:::čay(u-)
-v:::j:::tcarq:::čarq:::čarq:::charq:::hang on with arm, deter:::note:::čarq
-v:::j:::tcäm̕:::čem̕:::čɛm':::che'm:::take hold of pl. object:::note:::čɛm'
-v:::j:::tcän̕:::čen̕:::čɛn':::che'n:::take hold of large object:::note:::čɛn'
+v:::š/sh:::ci'<sup>ɩ</sup>:::šiʔ:::šiʔ:::shi':::be fastidious::: :::šiʔ
+v:::š/sh:::ci'<sup>ɩ</sup>t:::šiʔt:::šiʔt:::shi't:::be first, oldest::: :::šiʔt
+v:::š/sh:::cip:::šip:::šip(-t):::ship(-t):::be slow, deliberate in action::: :::šip(-t)
+v:::š/sh:::cip:::šip:::šip:::ship:::complete task::: :::šip
+v:::š/sh:::cip:::šip:::šip:::ship:::possess without interference::: :::šip
+v:::š/sh:::cim̕:::šim̕:::šim':::shi'm:::benefit::: :::šim'
+v:::š/sh:::ciw̕:::šiw̕:::šiw':::shi'w:::be girl::: :::šiw'
+v:::š/sh:::ciɬ:::šiɬ:::šiɫ(u-):::shiɫ(u-):::fit, be exact, correct::: :::šiɫ(u-)
+v:::š/sh:::cɩcɩl̕:::[no root]:::šəšəl'(u-):::shsh'l(u-):::be very fine::: :::šəšəl'(u-)
+v:::j:::jar̕:::ǰar̕:::ǰar':::ja'r:::be firm, strong::: :::ǰar'
+v:::j:::djäm:::ǰem:::ǰɛm:::jem:::pin, brace::: :::ǰɛm
+v:::j:::djäy̕djiy̕:::ǰey̕:::ǰɛy'ǰiy'(-t):::je'yji'y(-t):::be ugly, homely, unsightly::: :::ǰɛy'ǰiy'(-t)
+v:::j:::djax̣:::ǰex̣:::ǰax̣:::jaqh:::mark by scratching::: :::ǰax̣
+v:::j:::tcastq:::častq:::častq:::chastq:::dig camas::: :::častq
+v:::j:::tcăy:::čay:::čay(u-):::chay(u-):::one is enduring, solid form::: :::čay(u-)
+v:::j:::tcarq:::čarq:::čarq:::charq:::hang on with arm, deter::: :::čarq
+v:::j:::tcäm̕:::čem̕:::čɛm':::che'm:::take hold of pl. object::: :::čɛm'
+v:::j:::tcän̕:::čen̕:::čɛn':::che'n:::take hold of large object::: :::čɛn'
 v:::j:::tcän̕šit:::čen̕:::čɛn'šit:::che'nshit:::help:::čén̕šeš 'aid; help'; čeɬ hi sčnšítm   I'm going to (go) help him:::čɛn'šit
-v:::j:::tcän̕xʷ:::čen̕xʷ:::čɛn'xʷ:::che'nkhw:::hit person with slight touch, bump into:::note:::čɛn'xʷ
-v:::j:::tcäc:::češ:::čɛš:::chesh:::accompany:::note:::čɛš
+v:::j:::tcän̕xʷ:::čen̕xʷ:::čɛn'xʷ:::che'nkhw:::hit person with slight touch, bump into::: :::čɛn'xʷ
+v:::j:::tcäc:::češ:::čɛš:::chesh:::accompany::: :::čɛš
 v:::j:::tcägw (čigʷ):::doak:::čɛgʷ:::chegw:::extend:::only examples are unstressed:::čɛgʷ
-v:::j:::tcäl:::čel:::čɛl:::chel:::await eagerly, anxiously:::note:::čɛl
-v:::j:::tcäl:::̕	čel̕:::čɛl':::che'l:::cough up:::note:::čɛl'
-v:::j:::tcäɬ:::čeɬ:::čɛɫ:::cheɫ:::separate, divorce, part:::note:::čɛɫ
-v:::j:::tci'<sup>ɩ</sup>:::čiʔ:::čiʔ:::chi':::open, uncover, unveil:::note:::čiʔ
-v:::j:::tci'<sup>ɩ</sup>ɬäs:::čiʔɬes:::čiʔɫɛs:::chi'ɫes:::three:::note:::čiʔɫɛs
-v:::j:::tcip:::čip:::čip:::chip:::soften:::note:::čip
-v:::j:::tcim̕:::čim̕:::čim':::chi'm:::disdain,turn away from:::note:::čim'
-v:::j:::tcits:::čic:::čic:::chits:::arrive:::note:::čic
-v:::j:::tcits:::doak:::čic:::chits:::find:::note:::čic
-v:::j:::tcigw:::čigʷ:::čigʷ:::chigw:::go out onto prairie:::note:::čigʷ
-v:::j:::tciɬ:::čiɬ:::čiɫ:::chiɫ:::give:::note:::čiɫ
-v:::j:::tcil̕:::čil̕:::čil':::chi'l:::nauseate:::note:::čil'
-v:::j:::tcuts:::doak:::čuc:::chuts:::be light person, behave affectedly:::note:::čuc
+v:::j:::tcäl:::čel:::čɛl:::chel:::await eagerly, anxiously::: :::čɛl
+v:::j:::tcäl:::̕	čel̕:::čɛl':::che'l:::cough up::: :::čɛl'
+v:::j:::tcäɬ:::čeɬ:::čɛɫ:::cheɫ:::separate, divorce, part::: :::čɛɫ
+v:::j:::tci'<sup>ɩ</sup>:::čiʔ:::čiʔ:::chi':::open, uncover, unveil::: :::čiʔ
+v:::j:::tci'<sup>ɩ</sup>ɬäs:::čiʔɬes:::čiʔɫɛs:::chi'ɫes:::three::: :::čiʔɫɛs
+v:::j:::tcip:::čip:::čip:::chip:::soften::: :::čip
+v:::j:::tcim̕:::čim̕:::čim':::chi'm:::disdain,turn away from::: :::čim'
+v:::j:::tcits:::čic:::čic:::chits:::arrive::: :::čic
+v:::j:::tcits:::doak:::čic:::chits:::find::: :::čic
+v:::j:::tcigw:::čigʷ:::čigʷ:::chigw:::go out onto prairie::: :::čigʷ
+v:::j:::tciɬ:::čiɬ:::čiɫ:::chiɫ:::give::: :::čiɫ
+v:::j:::tcil̕:::čil̕:::čil':::chi'l:::nauseate::: :::čil'
+v:::j:::tcuts:::doak:::čuc:::chuts:::be light person, behave affectedly::: :::čuc
 v:::j:::tcɩp:::čip:::čəp(u-):::chp(u-):::be unexpectedly soft:::(čəp is unstressed form):::čəp(u-)
-v:::j:::tcɩcip:::čšip:::čəšip:::chship:::chase:::note:::čəšip
+v:::j:::tcɩcip:::čšip:::čəšip:::chship:::chase::: :::čəšip
 v:::j:::tcᴇtcaʀ̕:::čaʕ:::čəčaʕ':::chcha(':::be slender and cylindrical:::with diminutive reduplication and glottalization:::čəčaʕ'
 v:::j:::tcɩtcip:::čip:::čəčip:::chchip:::be soft and smooth (like fur):::with diminutive reduplication:::čəčip
-v:::j:::tcɩtcmin:::ččmin:::čəčmin:::chchmin:::throw one object:::note:::čəčmin
-v:::j:::tcɩɬip:::čɬip:::čəɫip:::chɫip:::hunt big game:::note:::čəɫip
+v:::j:::tcɩtcmin:::ččmin:::čəčmin:::chchmin:::throw one object::: :::čəčmin
+v:::j:::tcɩɬip:::čɬip:::čəɫip:::chɫip:::hunt big game::: :::čəɫip
 v:::j:::tcụpxʷ:::čepxʷ:::čəpxʷ:::chpkhw:::snap with finger:::čépxʷnc 'he snapped it with his finger':::čəpxʷ
-v:::č'/ch':::tc̕t:::č̕et:::č'at(u-):::ch'at(u-):::tick, beat:::note:::č'at(u-)
+v:::č'/ch':::tc̕t:::č̕et:::č'at(u-):::ch'at(u-):::tick, beat::: :::č'at(u-)
 v:::č'/ch':::tc̕ax̣ʷ:::c̕ax̣:::č'ax̣ʷ:::ch'aqhw:::shove, move to one side:::Felix Aripa:::č'ax̣ʷ
-v:::č'/ch':::tc̕ar:::č̕ar:::č'ar:::ch'ar:::cut flimsy object with shears:::note:::č'ar
-v:::č'/ch':::tc̕ar:::č̕ar:::č'ar:::ch'ar:::animal swims:::note:::č'ar
+v:::č'/ch':::tc̕ar:::č̕ar:::č'ar:::ch'ar:::cut flimsy object with shears::: :::č'ar
+v:::č'/ch':::tc̕ar:::č̕ar:::č'ar:::ch'ar:::animal swims::: :::č'ar
 v:::č'/ch':::tc̕ar:::č̕ar:::č'ar:::ch'ar:::band lies without exerting pressure:::as 'furrow', w/ lxs:::č'ar
 v:::č'/ch':::tcä'<sup>ä</sup>c:::č̕eʔš:::č'aʔš:::ch'a'sh:::condescend:::LN:::č'aʔš
 v:::č'/ch':::tc̕äp̕xʷ:::č̕ep̕uxʷ:::č'ɛp'xʷ:::ch'ep'khw:::clip, click:::č̕púxʷ 'click'; č̕épxʷ 'pinched':::č'ɛp'xʷ
-v:::č'/ch':::tc̕äm:::č̕em:::č'ɛm:::ch'em:::be surface:::note:::č'ɛm
-v:::č'/ch':::tc̕äm̕:::č̕em̕:::č'ɛm':::ch'e'm:::be dark (as night):::note:::č'ɛm'
-v:::č'/ch':::tc̕äw:::č̕ew:::č'ɛw:::ch'ew:::be depressing:::note:::č'ɛw
-v:::č'/ch':::tc̕äw̕:::č̕ew̕:::č'ɛw':::ch'e'w:::be large cylinder shaped:::note:::č'ɛw'
-v:::č'/ch':::tc̕äd:::č̕id; č̕ed:::č'ɛd:::ch'ed:::shade:::note:::č'ɛd
-v:::č'/ch':::tc̕ät̕:::č̕et̕:::č'ɛt':::ch'et':::cut off completely:::note:::č'ɛt'
-v:::č'/ch':::tc̕änp̕:::č̕enp̕:::č'ɛnp':::ch'enp':::clasp, encircle:::note:::č'ɛnp'
-v:::č'/ch':::tc̕än̕:::č̕en̕:::č'ɛn':::ch'e'n:::one round object lies:::note:::č'ɛn'
-v:::č'/ch':::tc̕äs:::č̕es:::č'ɛs(-t):::ch'es(-t):::be bad:::note:::č'ɛs(-t)
-v:::č'/ch':::tc̕äts̕:::č̕ec̕:::č'ɛc':::ch'ets':::one long object lies:::note:::č'ɛc'
-v:::č'/ch':::tc̕äts:::č̕ec:::č'ɛc:::ch'ets:::be stupid:::note:::č'ɛc
-v:::č'/ch':::tc̕äxʷ:::doak:::č'ɛxʷ:::ch'ekhw:::peck at hard object (as woodpecker):::note:::č'ɛxʷ
-v:::č'/ch':::tc̕äx̣:::č̕ex̣:::č'ɛx̣:::ch'eqh:::rub against	as 'move aside':::note:::č'ɛx̣
-v:::č'/ch':::tc̕äl:::č̕el:::č'ɛl:::ch'el:::be bark:::note:::č'ɛl
+v:::č'/ch':::tc̕äm:::č̕em:::č'ɛm:::ch'em:::be surface::: :::č'ɛm
+v:::č'/ch':::tc̕äm̕:::č̕em̕:::č'ɛm':::ch'e'm:::be dark (as night)::: :::č'ɛm'
+v:::č'/ch':::tc̕äw:::č̕ew:::č'ɛw:::ch'ew:::be depressing::: :::č'ɛw
+v:::č'/ch':::tc̕äw̕:::č̕ew̕:::č'ɛw':::ch'e'w:::be large cylinder shaped::: :::č'ɛw'
+v:::č'/ch':::tc̕äd:::č̕id; č̕ed:::č'ɛd:::ch'ed:::shade::: :::č'ɛd
+v:::č'/ch':::tc̕ät̕:::č̕et̕:::č'ɛt':::ch'et':::cut off completely::: :::č'ɛt'
+v:::č'/ch':::tc̕änp̕:::č̕enp̕:::č'ɛnp':::ch'enp':::clasp, encircle::: :::č'ɛnp'
+v:::č'/ch':::tc̕än̕:::č̕en̕:::č'ɛn':::ch'e'n:::one round object lies::: :::č'ɛn'
+v:::č'/ch':::tc̕äs:::č̕es:::č'ɛs(-t):::ch'es(-t):::be bad::: :::č'ɛs(-t)
+v:::č'/ch':::tc̕äts̕:::č̕ec̕:::č'ɛc':::ch'ets':::one long object lies::: :::č'ɛc'
+v:::č'/ch':::tc̕äts:::č̕ec:::č'ɛc:::ch'ets:::be stupid::: :::č'ɛc
+v:::č'/ch':::tc̕äxʷ:::doak:::č'ɛxʷ:::ch'ekhw:::peck at hard object (as woodpecker)::: :::č'ɛxʷ
+v:::č'/ch':::tc̕äx̣:::č̕ex̣:::č'ɛx̣:::ch'eqh:::rub against	as 'move aside'::: :::č'ɛx̣
+v:::č'/ch':::tc̕äl:::č̕el:::č'ɛl:::ch'el:::be bark::: :::č'ɛl
 v:::č'/ch':::tc̕älxʷ:::č̕elxʷ:::č'ɛlxʷ(x̣ʷ):::ch'elkhw(qhw):::be concave:::upside down, concave side down:::č'ɛlxʷ(x̣ʷ)
 v:::č'/ch':::tc̕äṛʷ:::č̕eʕʷ:::č'aʕʷ:::ch'a(w:::pray:::R has e (a umlaut):::č'aʕʷ
 v:::č'/ch':::tc̕ip̕:::c̕ip:::č'ip':::ch'ip':::pinch:::c̕ip̕ or č̕ep̕uxʷ:::č'ip'
-v:::č'/ch':::tc̕im:::č̕im:::č'im:::ch'im:::grab-some:::note:::č'im
-v:::č'/ch':::tc̕id:::č̕id:::č'id(u-):::ch'id(u-):::be shadowy:::note:::č'id(u-)
-v:::č'/ch':::tc̕it-ä'<sup>ä</sup>:::č̕iteʔ:::č'it-ɛʔ:::ch'it-e':::be near:::note:::č'it-ɛʔ
+v:::č'/ch':::tc̕im:::č̕im:::č'im:::ch'im:::grab-some::: :::č'im
+v:::č'/ch':::tc̕id:::č̕id:::č'id(u-):::ch'id(u-):::be shadowy::: :::č'id(u-)
+v:::č'/ch':::tc̕it-ä'<sup>ä</sup>:::č̕iteʔ:::č'it-ɛʔ:::ch'it-e':::be near::: :::č'it-ɛʔ
 v:::č'/ch':::tc̕in̕:::č̕in:::č'in':::ch'i'n:::be dangerous:::LN, R's texts have no glottalization on C2:::č'in'
-v:::č'/ch':::tc̕ixʷ:::č̕ixʷ:::č'ixʷ:::ch'ikhw:::lean:::note:::č'ixʷ
-v:::č'/ch':::tc̕ih:::č̕ih:::č'ih:::ch'ih:::approach, get near:::note:::č'ih
+v:::č'/ch':::tc̕ixʷ:::č̕ixʷ:::č'ixʷ:::ch'ikhw:::lean::: :::č'ixʷ
+v:::č'/ch':::tc̕ih:::č̕ih:::č'ih:::ch'ih:::approach, get near::: :::č'ih
 v:::č'/ch':::tc̕u<sup>u</sup>:::č̕uw:::ču:::chu:::be absent, gone, missing, empty:::R has glottalized non-nasals:::ču
 v:::č'/ch':::tc̕ɩtc̕än̕-ä'<sup>ä</sup>:::č̕eneʔ:::č'əčɛn'-ɛʔ:::ch'che'n-e':::one is small:::always diminutive, with C1 redup and nasal glottalized:::č'əčɛn'-ɛʔ
-v:::č'/ch':::tc̕ɩt̕:::č'ət'(u-):::č'ət'(u-):::ch't'(u-):::be brown:::note:::č'ət'(u-)
+v:::č'/ch':::tc̕ɩt̕:::č'ət'(u-):::č'ət'(u-):::ch't'(u-):::be brown::: :::č'ət'(u-)
 v:::č'/ch':::tc̕ụp̕xʷ:::č̕ep̕uxʷ:::č'əp'xʷ(u-):::ch'p'khw(u-):::it went click:::(see clip, click) R's form unstressed:::č'əp'xʷ(u-)
-v:::č'/ch':::tc̕ụxʷ:::č'əxʷ:::č'əxʷ:::ch'khw:::retire from pursuit (prog. dis.):::note:::č'əxʷ
-v:::y:::yanuq̕ʷ:::yanq̕ʷ:::yanuq'ʷ:::yanuq'w:::snake is coiled:::note:::yanuq'ʷ
-v:::y:::yats̕:::yac̕/yoc̕:::yac'(u-):::yats'(u-):::be tight (as belt or rope) (prog. dis.):::note:::yac'(u-)
-v:::y:::yaq̕:::yaq̕:::yaq':::yaq':::file, whet:::note:::yaq'
-v:::y:::yar:::yar:::yar:::yar:::hooplike object rolls:::note:::yar
+v:::č'/ch':::tc̕ụxʷ:::č'əxʷ:::č'əxʷ:::ch'khw:::retire from pursuit (prog. dis.)::: :::č'əxʷ
+v:::y:::yanuq̕ʷ:::yanq̕ʷ:::yanuq'ʷ:::yanuq'w:::snake is coiled::: :::yanuq'ʷ
+v:::y:::yats̕:::yac̕/yoc̕:::yac'(u-):::yats'(u-):::be tight (as belt or rope) (prog. dis.)::: :::yac'(u-)
+v:::y:::yaq̕:::yaq̕:::yaq':::yaq':::file, whet::: :::yaq'
+v:::y:::yar:::yar:::yar:::yar:::hooplike object rolls::: :::yar
 v:::y:::yar:::yar:::yar:::yar:::be torch:::with =us 'fire/face':::yar
-v:::y:::yarp̕:::yarp̕:::yarp':::yarp':::loop lies:::note:::yarp'
-v:::y:::yark̕ʷ:::yark̕ʷ:::yark'ʷ:::yark'w:::be curved, crooked:::note:::yark'ʷ
-v:::y:::yaʀ:::yaʕ:::yaʕ:::ya(:::lack, need, be scarce:::note:::yaʕ
-v:::y:::yaʀ:::yaʕ; yaʕ̕:::yaʕ:::ya(:::assemble, be many, gather, crowd:::note:::yaʕ
-v:::y:::yaʀ:::?yaʕ̕eʔ:::yaʕ:::ya(:::be shy, timid, uncertain, hesitant:::note:::yaʕ
+v:::y:::yarp̕:::yarp̕:::yarp':::yarp':::loop lies::: :::yarp'
+v:::y:::yark̕ʷ:::yark̕ʷ:::yark'ʷ:::yark'w:::be curved, crooked::: :::yark'ʷ
+v:::y:::yaʀ:::yaʕ:::yaʕ:::ya(:::lack, need, be scarce::: :::yaʕ
+v:::y:::yaʀ:::yaʕ; yaʕ̕:::yaʕ:::ya(:::assemble, be many, gather, crowd::: :::yaʕ
+v:::y:::yaʀ:::?yaʕ̕eʔ:::yaʕ:::ya(:::be shy, timid, uncertain, hesitant::: :::yaʕ
 v:::y:::yä'<sup>ä</sup>:::ye-:::yɛʔ:::ye':::procure game:::prefix, not stem:::yɛʔ
-v:::y:::yäp̕:::yep':::yɛp':::yep':::sway, rock:::note:::yɛp'
-v:::y:::yäm:::yem:::yɛm:::yem:::be silent:::note:::yɛm
-v:::y:::yäm:::doak:::yɛm:::yem:::earn, score:::note:::yɛm
-v:::y:::yätkʷ:::yetkʷ:::yɛtkʷ:::yetkw:::wood is rotten:::note:::yɛtkʷ
+v:::y:::yäp̕:::yep':::yɛp':::yep':::sway, rock::: :::yɛp'
+v:::y:::yäm:::yem:::yɛm:::yem:::be silent::: :::yɛm
+v:::y:::yäm:::doak:::yɛm:::yem:::earn, score::: :::yɛm
+v:::y:::yätkʷ:::yetkʷ:::yɛtkʷ:::yetkw:::wood is rotten::: :::yɛtkʷ
 v:::y:::yänp̕:::yenp̕:::yɛnp':::yenp':::clamp screw:::(vowel unverified):::yɛnp'
-v:::y:::yäl̕xʷ:::yel̕xʷ:::yɛl'xʷ:::ye'lkhw:::cover with material:::note:::yɛl'xʷ
-v:::y:::yim̕:::yim̕:::yim':::yi'm:::trap by surrounding:::note:::yim'
-v:::y:::yit̕:::yit̕:::yit':::yit':::stir (as mush):::note:::yit'
-v:::y:::yil̕:::yil̕:::yil':::yi'l:::defense is approached:::note:::yil'
+v:::y:::yäl̕xʷ:::yel̕xʷ:::yɛl'xʷ:::ye'lkhw:::cover with material::: :::yɛl'xʷ
+v:::y:::yim̕:::yim̕:::yim':::yi'm:::trap by surrounding::: :::yim'
+v:::y:::yit̕:::yit̕:::yit':::yit':::stir (as mush)::: :::yit'
+v:::y:::yil̕:::yil̕:::yil':::yi'l:::defense is approached::: :::yil'
 v:::y:::yirk̕ʷ:::yark̕ʷ:::yirk'ʷ:::yirk'w:::be curved:::yirk̕ʷ unexpected and unverified (no [i] before r):::yirk'ʷ
-v:::y:::yih:::yih:::yih:::yih:::be calm, quiet:::note:::yih
-v:::y:::yuts̕:::yuc':::yuc':::yuts':::be beaver castoreum:::note:::yuc'
-v:::y:::yɩts̕ᴐp:::yəcɔp:::yəcɔp:::ytsop:::shaking object becomes firm:::note:::yəcɔp
-v:::y:::yᴇṛʷpiy̕igwt:::yəʕʷpiy'igʷt:::yəʕʷpiy'igʷt:::y(wpi'yigwt:::be able, capable, dependable, reasonable, willing:::note:::yəʕʷpiy'igʷt
+v:::y:::yih:::yih:::yih:::yih:::be calm, quiet::: :::yih
+v:::y:::yuts̕:::yuc':::yuc':::yuts':::be beaver castoreum::: :::yuc'
+v:::y:::yɩts̕ᴐp:::yəcɔp:::yəcɔp:::ytsop:::shaking object becomes firm::: :::yəcɔp
+v:::y:::yᴇṛʷpiy̕igwt:::yəʕʷpiy'igʷt:::yəʕʷpiy'igʷt:::y(wpi'yigwt:::be able, capable, dependable, reasonable, willing::: :::yəʕʷpiy'igʷt
 v:::y:::yuqʷ:::yoqʷ:::yuqʷ:::yuqw:::pretend:::one form, in attack 6.7.  unexpected:::yuqʷ
-v:::y:::yᴐqʷ:::yoqʷ:::yɔqʷ:::yoqw:::pretend with something (to do something):::note:::yɔqʷ
-v:::y':::y̕aʀ̕pqin̕:::y̕aʕ̕p (√yaʕ):::y'aʕ'pqin':::'ya('pqi'n:::be many, much:::note:::y'aʕ'pqin'ʷ
-v:::y':::y̕ᴐqʷ:::y̕oqʷ:::y'ɔqʷ:::'yoqw:::tell lie:::note:::y'ɔqʷ
-v:::gʷ/gw:::gum:::gʷum:::gum:::gum:::crumble, be crummy:::note:::gum
-v:::gʷ/gw:::gwaq:::gʷaq:::gʷaq:::gwaq:::be roomy:::note:::gʷaq
-v:::gʷ/gw:::gwaq̕:::gʷaq̕:::gʷaq':::gwaq':::spread apart as to part hair, remove layers:::note:::gʷaq'
-v:::gʷ/gw:::gwax̣:::gʷax̣:::gʷax̣(-t):::gwaqh(-t):::be young:::note:::gʷax̣(-t)
+v:::y:::yᴐqʷ:::yoqʷ:::yɔqʷ:::yoqw:::pretend with something (to do something)::: :::yɔqʷ
+v:::y':::y̕aʀ̕pqin̕:::y̕aʕ̕p (√yaʕ):::y'aʕ'pqin':::'ya('pqi'n:::be many, much::: :::y'aʕ'pqin'ʷ
+v:::y':::y̕ᴐqʷ:::y̕oqʷ:::y'ɔqʷ:::'yoqw:::tell lie::: :::y'ɔqʷ
+v:::gʷ/gw:::gum:::gʷum:::gum:::gum:::crumble, be crummy::: :::gum
+v:::gʷ/gw:::gwaq:::gʷaq:::gʷaq:::gwaq:::be roomy::: :::gʷaq
+v:::gʷ/gw:::gwaq̕:::gʷaq̕:::gʷaq':::gwaq':::spread apart as to part hair, remove layers::: :::gʷaq'
+v:::gʷ/gw:::gwax̣:::gʷax̣:::gʷax̣(-t):::gwaqh(-t):::be young::: :::gʷax̣(-t)
 v:::gʷ/gw:::gwalq̕:::gʷalq̕:::gʷalq':::gwalq':::uncover pit over:::upside down FA 1999:::gʷalq'
-v:::gʷ/gw:::gwar:::gʷar:::gʷar:::gwar:::scrape:::note:::gʷar
-v:::gʷ/gw:::gwar̕:::gʷar̕:::gʷar':::gwa'r:::be silvery, clear:::note:::gʷar'
-v:::gʷ/gw:::gwäp:::gʷep:::gʷɛp:::gwep:::be hairy, grassy:::note:::gʷɛp
-v:::gʷ/gw:::gwät̕tc̕:::gʷet̕č̕:::gʷɛt'č':::gwet'ch':::prong, gore:::note:::gʷɛt'č
-v:::gʷ/gw:::gwäc:::gʷeš:::gʷɛš:::gwesh:::comb:::note:::gʷɛš
-v:::gʷ/gw:::gwitct:::gʷič:::gʷičt:::gwicht:::see:::note:::gʷičt
-v:::gʷ/gw:::gwän:::gʷen:::gʷɛn:::gwen:::be below, deep, low:::note:::gʷɛn
-v:::gʷ/gw:::gwäs:::gʷes:::gʷɛs:::gwes:::spin, twist thread:::note:::gʷɛs
-v:::gʷ/gw:::gwäy̕:::gʷey̕:::gʷɛy':::gwe'y:::finish:::note:::gʷɛy'
-v:::gʷ/gw:::gwäxʷ:::gʷexʷ:::gʷɛxʷ:::gwekhw:::pl. objects hang:::note:::gʷɛxʷ
-v:::gʷ/gw:::reichard:::gʷel:::gʷɛl:::gwel:::burn blaze:::note:::gʷɛl
-v:::gʷ/gw:::gwäl̕:::gʷel̕:::gʷɛl':::gwe'l:::tilt:::note:::gʷɛl'
-v:::gʷ/gw:::gwiw:::gʷiw̕:::gʷiw:::gwiw:::wear in shreds:::note:::gʷiw
-v:::gʷ/gw:::gwis:::gʷis:::gʷis:::gwis:::be high:::note:::gʷis
-v:::gʷ/gw:::gwit̕s:::gʷic̕:::gʷic':::gwits':::pick out with stick:::note:::gʷic'
-v:::gʷ/gw:::gwic:::gʷiš:::gʷiš:::gwish:::be weir:::note:::gʷiš
-v:::gʷ/gw:::gwitc̕:::gʷič̕:::gʷič':::gwich':::be kindling:::note:::gʷič'
-v:::gʷ/gw:::gwigwäp:::gʷip:::gʷigʷɛp:::gwigwep:::step back:::note:::gʷigʷɛp
-v:::gʷ/gw:::gwil:::gʷil:::gʷil:::gwil:::trust:::note:::gʷil
-v:::gʷ/gw:::gwᴐq:::gʷɔq:::gʷɔq:::gwoq:::make way through crowd:::note:::gʷɔq
+v:::gʷ/gw:::gwar:::gʷar:::gʷar:::gwar:::scrape::: :::gʷar
+v:::gʷ/gw:::gwar̕:::gʷar̕:::gʷar':::gwa'r:::be silvery, clear::: :::gʷar'
+v:::gʷ/gw:::gwäp:::gʷep:::gʷɛp:::gwep:::be hairy, grassy::: :::gʷɛp
+v:::gʷ/gw:::gwät̕tc̕:::gʷet̕č̕:::gʷɛt'č':::gwet'ch':::prong, gore::: :::gʷɛt'č
+v:::gʷ/gw:::gwäc:::gʷeš:::gʷɛš:::gwesh:::comb::: :::gʷɛš
+v:::gʷ/gw:::gwitct:::gʷič:::gʷičt:::gwicht:::see::: :::gʷičt
+v:::gʷ/gw:::gwän:::gʷen:::gʷɛn:::gwen:::be below, deep, low::: :::gʷɛn
+v:::gʷ/gw:::gwäs:::gʷes:::gʷɛs:::gwes:::spin, twist thread::: :::gʷɛs
+v:::gʷ/gw:::gwäy̕:::gʷey̕:::gʷɛy':::gwe'y:::finish::: :::gʷɛy'
+v:::gʷ/gw:::gwäxʷ:::gʷexʷ:::gʷɛxʷ:::gwekhw:::pl. objects hang::: :::gʷɛxʷ
+v:::gʷ/gw:::reichard:::gʷel:::gʷɛl:::gwel:::burn blaze::: :::gʷɛl
+v:::gʷ/gw:::gwäl̕:::gʷel̕:::gʷɛl':::gwe'l:::tilt::: :::gʷɛl'
+v:::gʷ/gw:::gwiw:::gʷiw̕:::gʷiw:::gwiw:::wear in shreds::: :::gʷiw
+v:::gʷ/gw:::gwis:::gʷis:::gʷis:::gwis:::be high::: :::gʷis
+v:::gʷ/gw:::gwit̕s:::gʷic̕:::gʷic':::gwits':::pick out with stick::: :::gʷic'
+v:::gʷ/gw:::gwic:::gʷiš:::gʷiš:::gwish:::be weir::: :::gʷiš
+v:::gʷ/gw:::gwitc̕:::gʷič̕:::gʷič':::gwich':::be kindling::: :::gʷič'
+v:::gʷ/gw:::gwigwäp:::gʷip:::gʷigʷɛp:::gwigwep:::step back::: :::gʷigʷɛp
+v:::gʷ/gw:::gwil:::gʷil:::gʷil:::gwil:::trust::: :::gʷil
+v:::gʷ/gw:::gwᴐq:::gʷɔq:::gʷɔq:::gwoq:::make way through crowd::: :::gʷɔq
 v:::gʷ/gw:::gwụnit:::gʷinit:::gʷənit:::gwnit:::call, summon:::ex of stress on V1 (MS toad 16 2.2):::gʷənit
-v:::gʷ/gw:::gwụnixʷ:::gʷnixʷ:::gʷənixʷ:::gwnikhw:::be true:::note:::gʷənixʷ
-v:::gʷ/gw:::gwụɬ:::gʷəɫ:::gʷəɫ:::gwɫ:::twinkle:::note:::gʷəɫ
+v:::gʷ/gw:::gwụnixʷ:::gʷnixʷ:::gʷənixʷ:::gwnikhw:::be true::: :::gʷənixʷ
+v:::gʷ/gw:::gwụɬ:::gʷəɫ:::gʷəɫ:::gwɫ:::twinkle::: :::gʷəɫ
 v:::kʷ/kw:::kus:::kʷus:::*kus(u-, -t):::kus(u-, -t):::be frisky, skittish, shy, timid:::*no Salishan transcription will include unlabialized k to represent these sounds:::kus(u-, -t)
-v:::kʷ/kw:::kus:::kʷus:::kus:::kus:::be curly:::note:::kus
+v:::kʷ/kw:::kus:::kʷus:::kus:::kus:::be curly::: :::kus
 v:::kʷ/kw:::kul:::kʷuɬ:::kul:::kul:::lend:::Reichard has barred l in original as well.:::kul
-v:::kʷ/kw:::kulsäts:::kulsɛc:::kulsɛc:::kulsets:::hire:::note:::kulsɛc
-v:::kʷ/kw:::kuɬ:::kʷuɬ:::kuɫ:::kuɫ:::borrow:::note:::kuɫ
-v:::kʷ/kw:::kʷar:::kʷar:::kʷar:::kwar:::be yellow:::note:::kʷar
-v:::kʷ/kw:::kʷäl̕:::kʷel̕:::kʷɛl':::kwe'l:::be hot, sunny, warm:::note:::kʷɛl'
+v:::kʷ/kw:::kulsäts:::kulsɛc:::kulsɛc:::kulsets:::hire::: :::kulsɛc
+v:::kʷ/kw:::kuɬ:::kʷuɬ:::kuɫ:::kuɫ:::borrow::: :::kuɫ
+v:::kʷ/kw:::kʷar:::kʷar:::kʷar:::kwar:::be yellow::: :::kʷar
+v:::kʷ/kw:::kʷäl̕:::kʷel̕:::kʷɛl':::kwe'l:::be hot, sunny, warm::: :::kʷɛl'
 v:::kʷ/kw:::kʷi'<sup>ɩ</sup>ts:::kʷic:::kʷiʔc:::kwi'ts:::early in morning, be dusk:::ʔ infix inchoative:::kʷiʔc
-v:::kʷ/kw:::kʷin:::kʷin:::kʷin:::kwin:::take hold of one small object:::note:::kʷin
-v:::kʷ/kw:::kʷin:::hnkʷin:::kʷin:::kwin:::sing (with hən-):::note:::kʷin
-v:::kʷ/kw:::kʷis:::kʷis:::kʷis(-t):::kwis(-t):::be named:::note:::kʷis(-t)
+v:::kʷ/kw:::kʷin:::kʷin:::kʷin:::kwin:::take hold of one small object::: :::kʷin
+v:::kʷ/kw:::kʷin:::hnkʷin:::kʷin:::kwin:::sing (with hən-)::: :::kʷin
+v:::kʷ/kw:::kʷis:::kʷis:::kʷis(-t):::kwis(-t):::be named::: :::kʷis(-t)
 v:::kʷ/kw:::kʷigw:::kʷigʷ:::kʷigʷ(-t):::kwigw(-t):::see faintly:::cuˑkʷígʷ only form; check to confirm prefix:::kʷigʷ(-t)
-v:::kʷ/kw:::kʷil:::kʷil:::kʷil:::kwil:::become red:::note:::kʷil
+v:::kʷ/kw:::kʷil:::kʷil:::kʷil:::kwil:::become red::: :::kʷil
 v:::kʷ/kw:::kʷụl:::kʷul/kʷəl:::kʷəl:::kwl:::be red:::LaSarte 11.01 ʔuˑkʷúl; kʷəl:::kʷəl
-v:::k'ʷ/k'w:::k̕us:::doak:::k'us:::k'us:::be easily split:::note:::k'us
-v:::k'ʷ/k'w:::k̕ustcä'<sup>ä</sup>:::doak:::k'usčɛʔ:::k'usche':::haunt, ghost:::note:::k'usčɛʔ
-v:::k'ʷ/k'w:::k̕ul̕:::doak:::k'ul':::k'u'l:::do, make fix:::note:::k'ul'
-v:::k'ʷ/k'w:::k̕ʷax̣:::doak:::k'ʷax̣:::k'waqh:::be claw:::note:::k'ʷax̣
-v:::k'ʷ/k'w:::k̕ʷäɬ:::doak:::k'ʷɛɫ:::k'weɫ:::tickle:::note:::k'ʷɛɫ
-v:::k'ʷ/k'w:::k̕ʷäɬc:::doak:::k'ʷɛɫš:::k'weɫsh:::shy at:::note:::k'ʷɛɫš
-v:::k'ʷ/k'w:::k̕ʷaʀ:::doak:::k'ʷaʕ:::k'wa(:::slide, slip, skid:::note:::k'ʷaʕ
-v:::k'ʷ/k'w:::k̕ʷät̕:::doak:::k'ʷɛt':::k'wet':::expose, be evident, plain:::note:::k'ʷɛt'
-v:::k'ʷ/k'w:::k̕ʷi'<sup>ɩ</sup>:::doak:::k'ʷiʔ::: k'wi':::bite:::note:::k'ʷiʔ
-v:::k'ʷ/k'w:::k̕ʷiy̕:::doak:::k'ʷiy':::k'wi'y:::easy, quietly, still:::note:::k'ʷiy'
-v:::k'ʷ/k'w:::k̕ʷit̕:::doak:::k'ʷit':::k'wit':::take off clothes:::note:::k'ʷit'
-v:::k'ʷ/k'w:::k̕ʷinc:::doak:::k'ʷinš:::k'winsh:::how many?:::note:::k'ʷinš
-v:::k'ʷ/k'w:::k̕ʷin̕:::doak:::k'ʷin':::k'wi'n:::try choose, consider, examine:::note:::k'ʷin'
-v:::xʷ/khw:::xui:::doak:::xui:::khui:::go:::note:::xui
-v:::xʷ/khw:::xuˑˑp:::doak:::xup(u-):::khup(u-):::increase magically:::note:::xup(u-)
-v:::xʷ/khw:::xu<sup>u</sup>p:::doak:::xup(u-):::khup(u-) :::show off:::note:::xup(u-)
-v:::xʷ/khw:::xups:::doak:::xups:::khups:::slap with tail:::note:::xups
-v:::xʷ/khw:::xum̕:::doak:::xum':::khu'm:::be homesick for, be lonely:::note:::xum'
-v:::xʷ/khw:::xus:::doak:::xus:::khus:::arouse:::note:::xus
-v:::xʷ/khw:::xul:::doak:::xul:::khul:::bore hole:::note:::xul
-v:::xʷ/khw:::xuɬ:::doak:::xuɫ:::khuɫ:::proceed to:::note:::xuɫ
-v:::xʷ/khw:::xʷam:::doak:::xʷam:::khwam:::be roan color:::note:::xʷam
-v:::xʷ/khw:::xʷar:::doak:::xʷar:::khwar:::tremble, quiver:::note:::xʷar
-v:::xʷ/khw:::xʷar:::doak:::xʷar:::khwar:::a very long time:::note:::xʷar
-v:::xʷ/khw:::xʷäp:::doak:::xʷɛp:::khwep:::spread, flatten out blanket:::note:::xʷɛp
-v:::xʷ/khw:::xʷäd:::doak:::xʷɛd:::khwed:::itch:::note:::xʷɛd
-v:::xʷ/khw:::xʷät:::doak:::xʷɛt:::khwet:::be exhausted, come to end:::note:::xʷɛt
-v:::xʷ/khw:::xʷät̕:::doak:::xʷɛt':::khwet':::move hurriedly:::note:::xʷɛt'
-v:::xʷ/khw:::xʷät̕k̕ʷ:::doak:::xʷɛt'k'ʷ:::khwet'k'w:::rise suddenly (like hair or wire):::note:::xʷɛt'k'ʷ
-v:::xʷ/khw:::xʷäts:::doak:::xʷɛc:::khwets:::suffer:::note:::xʷɛc
-v:::xʷ/khw:::xụxʷäy̕ä'<sup>ä</sup>:::doak:::xʷəxʷɛy'ɛʔ:::khwkhwe'ye':::be narrow:::note:::xʷəxʷɛy'ɛʔ
-v:::xʷ/khw:::xʷäk̕ʷ:::doak:::xʷɛk'ʷ:::khwek'w:::clean, sweep:::note:::xʷɛk'ʷ
-v:::xʷ/khw:::xʷäl:::doak:::xʷɛl:::khwel:::clean material like moss, cotton:::note:::xʷɛl
-v:::xʷ/khw:::xʷäl:::doak:::xʷɛl:::khwel:::be alive, live:::note:::xʷɛl
-v:::xʷ/khw:::xʷäl̕:::doak:::xʷɛl':::khwe'l:::set to spinning (as a top):::note:::xʷɛl'
-v:::xʷ/khw:::xʷäṛ-ɩc:::doak:::xʷɛʕ-əš:::khwe(-sh:::step over a person ceremonially:::note:::xʷɛʕ-əš
-v:::xʷ/khw:::xʷi'<sup>ɩ</sup>:::doak:::xʷiʔ:::khwi':::here at this moment:::note:::xʷiʔ
-v:::xʷ/khw:::xʷi'<sup>ɩ</sup>t:::doak:::xʷiʔt:::khwi't:::attack, abuse with words or act:::note:::xʷiʔt
-v:::xʷ/khw:::xʷit:::doak:::xʷit:::khwit:::entertain, amuse:::note:::xʷit
-v:::xʷ/khw:::xʷi'<sup>ɩ</sup>n:::doak:::xʷiʔn:::khwi'n:::go along here:::note:::xʷiʔn
-v:::xʷ/khw:::xʷis:::doak:::xʷis(-t):::khwis(-t):::one travels, goes about:::note:::xʷis(-t)
-v:::xʷ/khw:::xụxʷits:::doak:::xʷəxʷic:::khwkhwits:::be short:::note:::xʷəxʷic
-v:::xʷ/khw:::xʷits̕:::doak:::xʷic':::khwits':::point toward:::note:::xʷic'
-v:::xʷ/khw:::xʷits̕:::doak:::xʷic':::khwits':::be helper to:::note:::xʷic'
-v:::xʷ/khw:::xwik̕ʷ:::doak:::xʷik'ʷ(-t):::khwik'w(-t):::be frosty:::note:::xʷik'ʷ(-t)
-v:::q:::qaqs:::doak:::qaqs:::qaqs:::serenade, sing war song:::note:::qaqs
-v:::q:::qax̣:::doak:::qax̣:::qaqh:::make x̣ sound:::note:::qax̣
-v:::q:::qäp:::doak:::qɛp:::qep:::pad:::note:::qɛp
-v:::q:::qäm:::doak:::qɛm:::qem:::be home:::note:::qɛm
-v:::q:::qäm:::doak:::qɛm:::qem:::be unconcerned, pay no attention:::note:::qɛm
-v:::q:::qäm:::doak:::qɛm:::qem:::have cramp:::note:::qɛm
-v:::q:::qäs:::doak:::qɛs:::qɛs:::scratch with nails:::note:::qɛs
-v:::q:::qäts:::doak:::qɛc:::qets:::shrink in quantity:::note:::qɛc
-v:::q:::qäq:::doak:::qɛq:::qeq:::cackle:::note:::qɛq
-v:::q:::qäl:::doak:::qɛl(u-):::qel(u-):::be fresh:::note:::qɛl(u-)
-v:::q:::qäɬ:::doak:::qɛɫ:::qeɫ:::be awake:::note:::qɛɫ
-v:::q:::qäɬ:::doak:::qɛɫ:::qeɫ:::overcome great resistance, lift, succeed at what seems impossible:::note:::qɛɫ
-v:::q:::qi'<sup>ɩ</sup>xʷ:::doak:::qiʔxʷ:::qi'khw:::smell, have odor:::note:::qiʔxʷ
-v:::q:::qigw:::doak:::qigʷ:::qigw:::dig roots:::note:::qigʷ
-v:::q:::qixʷ:::doak:::qixʷ:::qikhw:::forbid, prevent from:::note:::qixʷ
-v:::q:::qilttc:::doak:::qiltč:::qiltch:::be inland:::note:::qiltč
-v:::q:::qiɬ:::doak:::qiɫ(-t):::qiɫ(-t):::wake up:::note:::qiɫ(-t)
-v:::q:::qum̕:::doak:::qum':::qu'm:::be dim, gray:::note:::qum'
-v:::q:::quɬ:::doak:::quɫ(u-):::quɫ(u-):::be dusty:::note:::quɫ(u-)
-v:::q:::qᴐqʷ:::doak:::qɔqʷ:::qoqw:::be mouldy:::note:::qɔqʷ
-v:::q':::q̕aq̕am̕̕iy̕ä'<sup>ä</sup>:::doak:::q'aq'am'iy''ɛʔ:::q'aq'a'mi'y'e':::fish:::note:::q'aq'am'iy''ɛʔ
-v:::q':::q̕ants-ic:::doak:::q'anc-iš:::q'ants-ish:::struggle for one's life (as in fire):::note:::q'anc-iš
-v:::q':::q̕äpqʷ:::doak:::q'ɛpqʷ:::q'epqw:::trap in crotch:::note:::q'ɛpqʷ
-v:::q':::q̕äm:::doak:::q'ɛm:::q'em:::desire, covet, long for:::note:::q'ɛm
-v:::q':::q̕äm:::doak:::q'ɛm:::q'em:::swallow:::note:::q'ɛm
-v:::q':::q̕äw:::doak:::q'ɛw:::q'ew:::break stiff object:::note:::q'ɛw
-v:::q':::q̕ädäm:::doak:::q'ɛdɛm:::q'edem:::refuse, be balky:::note:::q'ɛdɛm
-v:::q':::q̕ät̕p:::doak:::q'ɛt'p:::q'et'p:::go up incline:::note:::q'ɛt'p
-v:::q':::q̕äsp:::doak:::q'ɛsp:::q'esp:::be long time, long ago:::note:::q'ɛsp
-v:::q':::q̕äts̕:::doak:::q'ɛc':::q'ets':::braid, intertwine, weave, knit:::note:::q'ɛc'
-v:::q':::q̕äy̕:::doak:::q'ɛy':::q'e'y:::be variegated, spotted:::note:::q'ɛy'
-v:::q':::q̕äy̕:::doak:::q'ɛy':::q'e'y:::make pattern, write, design, take picture:::note:::q'ɛy'
-v:::q':::q̕äxʷ:::doak:::q'ɛxʷ:::q'ekhw:::be proud:::note:::q'ɛxʷ
-v:::q':::q̕äx̣:::doak:::q'ɛx̣:::q'eqh:::be frugal, grudging:::note:::q'ɛx̣
-v:::q':::q̕äxʷ:::doak:::q'ɛxʷ:::q'ekhw:::be lustful, have desire:::note:::q'ɛxʷ
-v:::q':::q̕äl:::doak:::q'ɛl:::q'el:::swing:::note:::q'ɛl
-v:::q':::q̕äl̕xʷ:::doak:::q'ɛl'xʷ:::q'e'lkhw:::hook over, into:::note:::q'ɛl'xʷ
-v:::q':::q̕i'<sup>ɩ</sup>:::doak:::q'iʔ:::q'i':::stick to, wedge into:::note:::q'iʔ
-v:::q':::q̕i'<sup>ɩ</sup>ts̕:::doak:::q'iʔc':::q'i'ts':::vegetation grows:::note:::q'iʔc'
-v:::q':::q̕iw:::doak:::q'iw:::q'iw:::witch:::note:::q'iw
-v:::q':::q̕iy̕:::doak:::q'iy':::q'i'y:::cleft:::note:::q'iy'
-v:::q':::q̕ɩq̕ixʷä'<sup>ä</sup>:::doak:::q'əq'ixʷɛʔ:::q'q'ikhwe':::few:::note:::q'əq'ixʷɛʔ
-v:::q':::q̕up̕:::doak:::q'up'(-t):::q'up'(-t):::rain:::note:::q'up'(-t)
-v:::q':::q̕ut̕:::doak:::q'ut':::q'ut':::be woven, knitted:::note:::q'ut'
-v:::q':::q̕uts:::doak:::q'uc:::q'uts:::be fat:::note:::q'uc
-v:::q':::q̕ul̕:::doak:::q'ul':::q'u'l:::produce:::note:::q'ul'
-v:::x̣/qh:::x̣a'<sup>a</sup>m:::doak:::x̣aʔm:::qha'm:::monster:::note:::x̣aʔm
-v:::x̣/qh:::x̣ax̣an̕ut:::doak:::x̣ax̣an'ut:::qhaqha'nut:::nine:::note:::x̣ax̣an'ut
-v:::x̣/qh:::x̣ats:::doak:::x̣ac:::qhats:::bet:::note:::x̣ac
-v:::x̣/qh:::x̣ats̕:::doak:::x̣ac'(u-):::qhats'(u-):::be queer:::note:::x̣ac'(u-)
-v:::x̣/qh:::x̣ay̕ɩc:::doak:::x̣ay'əš:::qha'ysh:::avenge:::note:::x̣ay'əš
-v:::x̣/qh:::x̣ay̕x̣iy̕:::doak:::x̣ay'xiy':::qha'ykhi'y:::one is large:::note:::x̣ay'xiy'
-v:::x̣/qh:::x̣aq̕:::doak:::x̣aq':::qhaq':::pay, reward:::note:::x̣aq'
-v:::x̣/qh:::x̣al:::doak:::x̣al:::qhal:::redhot:::note:::x̣al
-v:::x̣/qh:::x̣aɬ:::doak:::x̣aɫ:::qhaɫ:::scare:::note:::x̣aɫ
-v:::x̣/qh:::x̣al:::doak:::x̣al:::qhal:::spy:::note:::x̣al
-v:::x̣/qh:::x̣aʀ:::doak:::x̣aʕ:::qha(:::fan:::note:::x̣aʕ
-v:::x̣/qh:::x̣äp:::doak:::x̣ɛp:::qhep:::pile flat objects:::note:::x̣ɛp
-v:::x̣/qh:::x̣äp̕:::doak:::x̣ɛp':::qhep':::button, fasten together, sew:::note:::x̣ɛp'
-v:::x̣/qh:::x̣äm:::doak:::x̣ɛm:::qhem:::bite:::note:::x̣ɛm
-v:::x̣/qh:::x̣äm:::doak:::x̣ɛm:::qhem:::be heavy:::note:::x̣ɛm
-v:::x̣/qh:::x̣ämäntsᴐtᴇn:::doak:::x̣ɛmɛncɔtən:::qhementsotn:::leave one's own people, go to live with in-laws (prog. dis.):::note:::x̣ɛmɛncɔtən
+v:::k'ʷ/k'w:::k̕us:::doak:::k'us:::k'us:::be easily split::: :::k'us
+v:::k'ʷ/k'w:::k̕ustcä'<sup>ä</sup>:::doak:::k'usčɛʔ:::k'usche':::haunt, ghost::: :::k'usčɛʔ
+v:::k'ʷ/k'w:::k̕ul̕:::doak:::k'ul':::k'u'l:::do, make fix::: :::k'ul'
+v:::k'ʷ/k'w:::k̕ʷax̣:::doak:::k'ʷax̣:::k'waqh:::be claw::: :::k'ʷax̣
+v:::k'ʷ/k'w:::k̕ʷäɬ:::doak:::k'ʷɛɫ:::k'weɫ:::tickle::: :::k'ʷɛɫ
+v:::k'ʷ/k'w:::k̕ʷäɬc:::doak:::k'ʷɛɫš:::k'weɫsh:::shy at::: :::k'ʷɛɫš
+v:::k'ʷ/k'w:::k̕ʷaʀ:::doak:::k'ʷaʕ:::k'wa(:::slide, slip, skid::: :::k'ʷaʕ
+v:::k'ʷ/k'w:::k̕ʷät̕:::doak:::k'ʷɛt':::k'wet':::expose, be evident, plain::: :::k'ʷɛt'
+v:::k'ʷ/k'w:::k̕ʷi'<sup>ɩ</sup>:::doak:::k'ʷiʔ::: k'wi':::bite::: :::k'ʷiʔ
+v:::k'ʷ/k'w:::k̕ʷiy̕:::doak:::k'ʷiy':::k'wi'y:::easy, quietly, still::: :::k'ʷiy'
+v:::k'ʷ/k'w:::k̕ʷit̕:::doak:::k'ʷit':::k'wit':::take off clothes::: :::k'ʷit'
+v:::k'ʷ/k'w:::k̕ʷinc:::doak:::k'ʷinš:::k'winsh:::how many?::: :::k'ʷinš
+v:::k'ʷ/k'w:::k̕ʷin̕:::doak:::k'ʷin':::k'wi'n:::try choose, consider, examine::: :::k'ʷin'
+v:::xʷ/khw:::xui:::doak:::xui:::khui:::go::: :::xui
+v:::xʷ/khw:::xuˑˑp:::doak:::xup(u-):::khup(u-):::increase magically::: :::xup(u-)
+v:::xʷ/khw:::xu<sup>u</sup>p:::doak:::xup(u-):::khup(u-) :::show off::: :::xup(u-)
+v:::xʷ/khw:::xups:::doak:::xups:::khups:::slap with tail::: :::xups
+v:::xʷ/khw:::xum̕:::doak:::xum':::khu'm:::be homesick for, be lonely::: :::xum'
+v:::xʷ/khw:::xus:::doak:::xus:::khus:::arouse::: :::xus
+v:::xʷ/khw:::xul:::doak:::xul:::khul:::bore hole::: :::xul
+v:::xʷ/khw:::xuɬ:::doak:::xuɫ:::khuɫ:::proceed to::: :::xuɫ
+v:::xʷ/khw:::xʷam:::doak:::xʷam:::khwam:::be roan color::: :::xʷam
+v:::xʷ/khw:::xʷar:::doak:::xʷar:::khwar:::tremble, quiver::: :::xʷar
+v:::xʷ/khw:::xʷar:::doak:::xʷar:::khwar:::a very long time::: :::xʷar
+v:::xʷ/khw:::xʷäp:::doak:::xʷɛp:::khwep:::spread, flatten out blanket::: :::xʷɛp
+v:::xʷ/khw:::xʷäd:::doak:::xʷɛd:::khwed:::itch::: :::xʷɛd
+v:::xʷ/khw:::xʷät:::doak:::xʷɛt:::khwet:::be exhausted, come to end::: :::xʷɛt
+v:::xʷ/khw:::xʷät̕:::doak:::xʷɛt':::khwet':::move hurriedly::: :::xʷɛt'
+v:::xʷ/khw:::xʷät̕k̕ʷ:::doak:::xʷɛt'k'ʷ:::khwet'k'w:::rise suddenly (like hair or wire)::: :::xʷɛt'k'ʷ
+v:::xʷ/khw:::xʷäts:::doak:::xʷɛc:::khwets:::suffer::: :::xʷɛc
+v:::xʷ/khw:::xụxʷäy̕ä'<sup>ä</sup>:::doak:::xʷəxʷɛy'ɛʔ:::khwkhwe'ye':::be narrow::: :::xʷəxʷɛy'ɛʔ
+v:::xʷ/khw:::xʷäk̕ʷ:::doak:::xʷɛk'ʷ:::khwek'w:::clean, sweep::: :::xʷɛk'ʷ
+v:::xʷ/khw:::xʷäl:::doak:::xʷɛl:::khwel:::clean material like moss, cotton::: :::xʷɛl
+v:::xʷ/khw:::xʷäl:::doak:::xʷɛl:::khwel:::be alive, live::: :::xʷɛl
+v:::xʷ/khw:::xʷäl̕:::doak:::xʷɛl':::khwe'l:::set to spinning (as a top)::: :::xʷɛl'
+v:::xʷ/khw:::xʷäṛ-ɩc:::doak:::xʷɛʕ-əš:::khwe(-sh:::step over a person ceremonially::: :::xʷɛʕ-əš
+v:::xʷ/khw:::xʷi'<sup>ɩ</sup>:::doak:::xʷiʔ:::khwi':::here at this moment::: :::xʷiʔ
+v:::xʷ/khw:::xʷi'<sup>ɩ</sup>t:::doak:::xʷiʔt:::khwi't:::attack, abuse with words or act::: :::xʷiʔt
+v:::xʷ/khw:::xʷit:::doak:::xʷit:::khwit:::entertain, amuse::: :::xʷit
+v:::xʷ/khw:::xʷi'<sup>ɩ</sup>n:::doak:::xʷiʔn:::khwi'n:::go along here::: :::xʷiʔn
+v:::xʷ/khw:::xʷis:::doak:::xʷis(-t):::khwis(-t):::one travels, goes about::: :::xʷis(-t)
+v:::xʷ/khw:::xụxʷits:::doak:::xʷəxʷic:::khwkhwits:::be short::: :::xʷəxʷic
+v:::xʷ/khw:::xʷits̕:::doak:::xʷic':::khwits':::point toward::: :::xʷic'
+v:::xʷ/khw:::xʷits̕:::doak:::xʷic':::khwits':::be helper to::: :::xʷic'
+v:::xʷ/khw:::xwik̕ʷ:::doak:::xʷik'ʷ(-t):::khwik'w(-t):::be frosty::: :::xʷik'ʷ(-t)
+v:::q:::qaqs:::doak:::qaqs:::qaqs:::serenade, sing war song::: :::qaqs
+v:::q:::qax̣:::doak:::qax̣:::qaqh:::make x̣ sound::: :::qax̣
+v:::q:::qäp:::doak:::qɛp:::qep:::pad::: :::qɛp
+v:::q:::qäm:::doak:::qɛm:::qem:::be home::: :::qɛm
+v:::q:::qäm:::doak:::qɛm:::qem:::be unconcerned, pay no attention::: :::qɛm
+v:::q:::qäm:::doak:::qɛm:::qem:::have cramp::: :::qɛm
+v:::q:::qäs:::doak:::qɛs:::qɛs:::scratch with nails::: :::qɛs
+v:::q:::qäts:::doak:::qɛc:::qets:::shrink in quantity::: :::qɛc
+v:::q:::qäq:::doak:::qɛq:::qeq:::cackle::: :::qɛq
+v:::q:::qäl:::doak:::qɛl(u-):::qel(u-):::be fresh::: :::qɛl(u-)
+v:::q:::qäɬ:::doak:::qɛɫ:::qeɫ:::be awake::: :::qɛɫ
+v:::q:::qäɬ:::doak:::qɛɫ:::qeɫ:::overcome great resistance, lift, succeed at what seems impossible::: :::qɛɫ
+v:::q:::qi'<sup>ɩ</sup>xʷ:::doak:::qiʔxʷ:::qi'khw:::smell, have odor::: :::qiʔxʷ
+v:::q:::qigw:::doak:::qigʷ:::qigw:::dig roots::: :::qigʷ
+v:::q:::qixʷ:::doak:::qixʷ:::qikhw:::forbid, prevent from::: :::qixʷ
+v:::q:::qilttc:::doak:::qiltč:::qiltch:::be inland::: :::qiltč
+v:::q:::qiɬ:::doak:::qiɫ(-t):::qiɫ(-t):::wake up::: :::qiɫ(-t)
+v:::q:::qum̕:::doak:::qum':::qu'm:::be dim, gray::: :::qum'
+v:::q:::quɬ:::doak:::quɫ(u-):::quɫ(u-):::be dusty::: :::quɫ(u-)
+v:::q:::qᴐqʷ:::doak:::qɔqʷ:::qoqw:::be mouldy::: :::qɔqʷ
+v:::q':::q̕aq̕am̕̕iy̕ä'<sup>ä</sup>:::doak:::q'aq'am'iy''ɛʔ:::q'aq'a'mi'y'e':::fish::: :::q'aq'am'iy''ɛʔ
+v:::q':::q̕ants-ic:::doak:::q'anc-iš:::q'ants-ish:::struggle for one's life (as in fire)::: :::q'anc-iš
+v:::q':::q̕äpqʷ:::doak:::q'ɛpqʷ:::q'epqw:::trap in crotch::: :::q'ɛpqʷ
+v:::q':::q̕äm:::doak:::q'ɛm:::q'em:::desire, covet, long for::: :::q'ɛm
+v:::q':::q̕äm:::doak:::q'ɛm:::q'em:::swallow::: :::q'ɛm
+v:::q':::q̕äw:::doak:::q'ɛw:::q'ew:::break stiff object::: :::q'ɛw
+v:::q':::q̕ädäm:::doak:::q'ɛdɛm:::q'edem:::refuse, be balky::: :::q'ɛdɛm
+v:::q':::q̕ät̕p:::doak:::q'ɛt'p:::q'et'p:::go up incline::: :::q'ɛt'p
+v:::q':::q̕äsp:::doak:::q'ɛsp:::q'esp:::be long time, long ago::: :::q'ɛsp
+v:::q':::q̕äts̕:::doak:::q'ɛc':::q'ets':::braid, intertwine, weave, knit::: :::q'ɛc'
+v:::q':::q̕äy̕:::doak:::q'ɛy':::q'e'y:::be variegated, spotted::: :::q'ɛy'
+v:::q':::q̕äy̕:::doak:::q'ɛy':::q'e'y:::make pattern, write, design, take picture::: :::q'ɛy'
+v:::q':::q̕äxʷ:::doak:::q'ɛxʷ:::q'ekhw:::be proud::: :::q'ɛxʷ
+v:::q':::q̕äx̣:::doak:::q'ɛx̣:::q'eqh:::be frugal, grudging::: :::q'ɛx̣
+v:::q':::q̕äxʷ:::doak:::q'ɛxʷ:::q'ekhw:::be lustful, have desire::: :::q'ɛxʷ
+v:::q':::q̕äl:::doak:::q'ɛl:::q'el:::swing::: :::q'ɛl
+v:::q':::q̕äl̕xʷ:::doak:::q'ɛl'xʷ:::q'e'lkhw:::hook over, into::: :::q'ɛl'xʷ
+v:::q':::q̕i'<sup>ɩ</sup>:::doak:::q'iʔ:::q'i':::stick to, wedge into::: :::q'iʔ
+v:::q':::q̕i'<sup>ɩ</sup>ts̕:::doak:::q'iʔc':::q'i'ts':::vegetation grows::: :::q'iʔc'
+v:::q':::q̕iw:::doak:::q'iw:::q'iw:::witch::: :::q'iw
+v:::q':::q̕iy̕:::doak:::q'iy':::q'i'y:::cleft::: :::q'iy'
+v:::q':::q̕ɩq̕ixʷä'<sup>ä</sup>:::doak:::q'əq'ixʷɛʔ:::q'q'ikhwe':::few::: :::q'əq'ixʷɛʔ
+v:::q':::q̕up̕:::doak:::q'up'(-t):::q'up'(-t):::rain::: :::q'up'(-t)
+v:::q':::q̕ut̕:::doak:::q'ut':::q'ut':::be woven, knitted::: :::q'ut'
+v:::q':::q̕uts:::doak:::q'uc:::q'uts:::be fat::: :::q'uc
+v:::q':::q̕ul̕:::doak:::q'ul':::q'u'l:::produce::: :::q'ul'
+v:::x̣/qh:::x̣a'<sup>a</sup>m:::doak:::x̣aʔm:::qha'm:::monster::: :::x̣aʔm
+v:::x̣/qh:::x̣ax̣an̕ut:::doak:::x̣ax̣an'ut:::qhaqha'nut:::nine::: :::x̣ax̣an'ut
+v:::x̣/qh:::x̣ats:::doak:::x̣ac:::qhats:::bet::: :::x̣ac
+v:::x̣/qh:::x̣ats̕:::doak:::x̣ac'(u-):::qhats'(u-):::be queer::: :::x̣ac'(u-)
+v:::x̣/qh:::x̣ay̕ɩc:::doak:::x̣ay'əš:::qha'ysh:::avenge::: :::x̣ay'əš
+v:::x̣/qh:::x̣ay̕x̣iy̕:::doak:::x̣ay'xiy':::qha'ykhi'y:::one is large::: :::x̣ay'xiy'
+v:::x̣/qh:::x̣aq̕:::doak:::x̣aq':::qhaq':::pay, reward::: :::x̣aq'
+v:::x̣/qh:::x̣al:::doak:::x̣al:::qhal:::redhot::: :::x̣al
+v:::x̣/qh:::x̣aɬ:::doak:::x̣aɫ:::qhaɫ:::scare::: :::x̣aɫ
+v:::x̣/qh:::x̣al:::doak:::x̣al:::qhal:::spy::: :::x̣al
+v:::x̣/qh:::x̣aʀ:::doak:::x̣aʕ:::qha(:::fan::: :::x̣aʕ
+v:::x̣/qh:::x̣äp:::doak:::x̣ɛp:::qhep:::pile flat objects::: :::x̣ɛp
+v:::x̣/qh:::x̣äp̕:::doak:::x̣ɛp':::qhep':::button, fasten together, sew::: :::x̣ɛp'
+v:::x̣/qh:::x̣äm:::doak:::x̣ɛm:::qhem:::bite::: :::x̣ɛm
+v:::x̣/qh:::x̣äm:::doak:::x̣ɛm:::qhem:::be heavy::: :::x̣ɛm
+v:::x̣/qh:::x̣ämäntsᴐtᴇn:::doak:::x̣ɛmɛncɔtən:::qhementsotn:::leave one's own people, go to live with in-laws (prog. dis.)::: :::x̣ɛmɛncɔtən
 v:::x̣/qh:::x̣ämintc:::doak:::̣ɛminč:::qheminch:::like, love:::note:::̣ɛminč
-v:::x̣/qh:::x̣ämts:::doak:::x̣ɛmc:::qhemts:::shave hair:::note:::x̣ɛmc
-v:::x̣/qh:::x̣ät:::doak:::x̣ɛt:::qhet:::punish:::note:::x̣ɛt
-v:::x̣/qh:::x̣ät:::doak:::x̣ɛt:::qhet:::club:::note:::x̣ɛt
-v:::x̣/qh:::x̣ät̕:::doak:::x̣ɛt':::qhet':::gnaw, eat close, graze:::note:::x̣ɛt'
-v:::x̣/qh:::x̣äs:::doak:::x̣ɛs:::qhes:::be well, be good:::note:::x̣ɛs
-v:::x̣/qh:::x̣äts:::doak:::x̣ɛc:::qhets:::be ready, clothed, get ready:::note:::x̣ɛc
-v:::x̣/qh:::x̣ätsut:::doak:::x̣ɛcut:::qhetsut:::be companion to:::note:::x̣ɛcut
-v:::x̣/qh:::x̣äts̕:::doak:::x̣ɛc'(u-):::qhets'(u-):::arouse curiosity:::note:::x̣ɛc'(u-)
-v:::x̣/qh:::x̣äy:::doak:::x̣ɛy:::qhey:::be left over:::note:::x̣ɛy
-v:::x̣/qh:::x̣äl:::doak:::x̣ɛl:::qhel:::lay evenly (as lumber):::note:::x̣ɛl
-v:::x̣/qh:::x̣äl:::doak:::x̣ɛl:::qhel:::be clear, bright, light:::note:::x̣ɛl
-v:::x̣/qh:::x̣äʀigw:::doak:::x̣ɛʕigʷ(-t):::qhe(igw(-t):::be full of holes so air can pass through:::note:::x̣ɛʕigʷ(-t)
-v:::x̣/qh:::x̣ip:::doak:::x̣ip:::qhip:::gnaw to destroy (as beaver, mouse, squirrel):::note:::x̣ip
-v:::x̣/qh:::x̣iw:::doak:::x̣iw:::qhiw:::be shy, timid, ashamed, embarrassed:::note:::x̣iw
-v:::x̣/qh:::x̣iw̕:::doak:::x̣iw':::qhi'w:::be raw (uncooked):::note:::x̣iw'
-v:::x̣/qh:::x̣it:::doak:::x̣it:::qhit:::be corrugated marked:::note:::x̣it
-v:::x̣/qh:::x̣its:::doak:::x̣ic:::qhits:::threaten with hand:::note:::x̣ic
-v:::x̣/qh:::x̣iy:::doak:::x̣iy:::qhiy:::gray (as horse):::note:::x̣iy
-v:::x̣/qh:::x̣il:::doak:::x̣il:::qhil:::lick from (as salt from ground):::note:::x̣il
-v:::x̣/qh:::x̣iɬ:::doak:::x̣iɫ:::qhiɫ:::fear:::note:::x̣iɫ
-v:::x̣/qh:::x̣iɬ:::doak:::x̣iɫ:::qhiɫ:::leave, desert:::note:::x̣iɫ
-v:::x̣/qh:::x̣us:::doak:::x̣us:::qhus:::foam (like beer):::note:::x̣us
-v:::x̣/qh:::x̣ᴐlq̕ʷ:::doak:::x̣ɔlq'ʷ:::qholq'w:::wind string evenly:::note:::x̣ɔlq'ʷ
-v:::qʷ/qw:::qʷa'<sup>a</sup>qʷä'<sup>ä</sup>l:::doak:::qʷaʔqʷɛʔl:::qwa'qwe'l:::speak, talk:::note:::qʷaʔqʷɛʔl
-v:::qʷ/qw:::qʷam:::doak:::qʷam:::qwam:::be pleasant, comfortable, fascinating, pleasing:::note:::qʷam
-v:::qʷ/qw:::qʷay:::doak:::qʷay:::qway:::joke, talk backward:::note:::qʷay
-v:::qʷ/qw:::qʷä'<sup>ä</sup>:::doak:::qʷɛʔ:::qwe':::continue with:::note:::qʷɛʔ
-v:::qʷ/qw:::qʷäm̕:::doak:::qʷɛm':::qwe'm:::ignore, be oblivious to:::note:::qʷɛm'
-v:::qʷ/qw:::qʷäs:::doak:::qʷɛs(u-):::qwes(u-):::blur, be foolish:::note:::qʷɛs(u-)
-v:::qʷ/qw:::qʷäy̕:::doak:::qʷɛy':::qwe'y:::be poor, pitiable, pity:::note:::qʷɛy'
-v:::qʷ/qw:::qʷäl̕:::doak:::qʷɛl':::qʷɛl':::be livid, bluish, angry:::note:::qʷɛl'
-v:::qʷ/qw:::qʷäṛʷ:::doak:::qʷɛʕʷ(u-):::qwe(w(u-):::be insane, drunk, foolish, irresponsible:::note:::qʷɛʕʷ(u-)
-v:::qʷ/qw:::qʷäl̕:::doak:::qʷɛl':::qwe'l:::enkindle, light:::note:::qʷɛl'
-v:::qʷ/qw:::qʷi'<sup>ɩ</sup>:::doak:::qʷiʔ:::qwi':::be hollow:::note:::qʷiʔ
-v:::qʷ/qw:::qʷi'<sup>ɩ</sup>:::doak:::qʷiʔ:::qwi':::be accustomed to:::note:::qʷiʔ
-v:::qʷ/qw:::qʷin:::doak:::qʷin:::qwin:::be blue:::note:::qʷin
-v:::qʷ/qw:::qʷits:::doak:::qʷic:::qwits:::be warm:::note:::qʷic
-v:::qʷ/qw:::qʷiy:::doak:::qʷiy(u-):::qwiy(u-):::have plenty:::note:::qʷiy(u-)
-v:::qʷ/qw:::qʷiy̕:::doak:::qʷiy'(-t):::qwi'y(-t):::have pity for:::note:::qʷiy'(-t)
-v:::qʷ/qw:::qʷil:::doak:::qʷil:::qwil:::cheat:::note:::qʷil
-v:::qʷ/qw:::qʷil̕:::doak:::qʷil':::qwi'l:::kindle, light, make fire:::note:::qʷil'
-v:::qʷ/qw:::qʷil̕:::doak:::qʷil':::qwi'l:::starve:::note:::qʷil'
-v:::qʷ/qw:::qʷuˑn:::doak:::qʷun(u-):::qwun(u-):::be blue, green:::note:::qʷun(u-)
-v:::q'ʷ/q'w:::reichard:::doak:::q'us:::q'us:::be gathered, wrinkled:::note:::q'us
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷal(-t):::q'wal(-t):::be black from burning:::note:::q'ʷal(-t)
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛd:::q'wed:::be black:::note:::q'ʷɛd
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛn'p':::q'we'np':::go out of sight, disappear:::note:::q'ʷɛn'p'
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛs:::q'wes:::be wrinkled, shriveled:::note:::q'ʷɛs
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛc:::q'wets:::pl. are enduring, solid, firm:::note:::q'ʷɛc
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛy':::q'we'y:::bounce, dance:::note:::q'ʷɛy'
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛy':::q'we'y:::wring, choke:::note:::q'ʷɛy'
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛl:::q'wel:::cook, burn:::note:::q'ʷɛl
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛɫ:::q'weɫ:::have endurance, be long-winded:::note:::q'ʷɛɫ
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷid:::q'wid:::make black, blacken:::note:::q'ʷid
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷiʔɫ:::q'wi'ɫ:::move camp, village travels:::note:::q'ʷiʔɫ
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷic'(-t):::q'wits'(-t):::be full:::note:::q'ʷic'(-t)
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷiɫ:::q'wiɫ:::be enduring, persevering (in general sense):::note:::q'ʷiɫ
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷih:::q'wih:::be black (in describing person):::note:::q'ʷih
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷəd(u-):::q'wd(u-):::be black (of horses):::note:::q'ʷəd(u-)
-v:::q'ʷ/q'w:::reichard:::doak:::q'ʷəliw:::q'wliw:::bear picks berries:::note:::q'ʷəliw
-v:::x̣ʷ/qhw:::x̣up:::doak:::x̣up:::qhup:::be inefficient, careless:::note:::x̣up
-v:::x̣ʷ/qhw:::x̣ʷad:::doak:::x̣ʷad:::qhwad:::be comical, be amused, laugh:::note:::x̣ʷad
-v:::x̣ʷ/qhw:::x̣ʷat:::doak:::x̣ʷat:::qhwat:::cut in two:::note:::x̣ʷat
-v:::x̣ʷ/qhw:::x̣ʷaq̕ʷ:::doak:::x̣ʷaq'ʷ:::qhwaq'w:::divide, separate:::note:::x̣ʷaq'ʷ
-v:::x̣ʷ/qhw:::x̣ʷaɬ:::doak:::x̣ʷaɫ:::qhwaɫ:::dart:::note:::x̣ʷaɫ
-v:::x̣ʷ/qhw:::x̣ʷän:::doak:::x̣ʷɛn(u-):::qhwen(u-):::hurry to get at:::note:::x̣ʷɛn(u-)
-v:::x̣ʷ/qhw:::x̣ʷäts:::doak:::x̣ʷɛc:::qhwets:::pass by:::note:::x̣ʷɛc
-v:::x̣ʷ/qhw:::x̣ʷäq̕ʷ:::doak:::x̣ʷɛq'ʷ:::qhweq'w:::grind meal:::note:::x̣ʷɛq'ʷ
-v:::x̣ʷ/qhw:::x̣ʷits:::doak:::x̣ʷic:::qhwits:::crop hair:::note:::x̣ʷic
-v:::x̣ʷ/qhw:::x̣ʷiɬ:::doak:::x̣ʷiɫ:::qhwiɫ:::hurry at something:::note:::x̣ʷiɫ
-v:::l:::la'ax̣ʷ:::doak:::laʔax̣̣ʷ:::la'aqhw:::be daytime, morning, tomorrow:::note:::laʔax̣̣ʷ
-v:::l:::laq:::doak:::laq:::laq:::pull out plants:::note:::laq
-v:::l:::laq̕:::doak:::laq':::laq':::pare, peel:::note:::laq'
-v:::l:::laqʷ:::doak:::laqʷ:::laqw:::store hanging (as tallow in paunch):::note:::laqʷ
-v:::l:::laq̕ʷ:::doak:::laq'ʷ:::laq'w:::be able:::note:::laq'ʷ
-v:::l:::lax̣ʷ:::doak:::lax̣ʷ:::laqhw:::pl. round objects lie:::note:::lax̣ʷ
-v:::l:::läp̕x̣ʷ:::doak:::lɛp'x̣ʷ:::lep'qhw:::fit into (as ball and socket):::note:::lɛp'x̣ʷ
-v:::l:::lädj:::doak:::lɛǰ(-p):::lej(-p):::stab:::note:::lɛǰ(-p)
-v:::l:::reichard:::doak:::lɛǰ:::lej:::sting:::note::: lɛǰ 
-v:::l:::lätc̕:::doak:::lɛč':::lech':::bind:::note:::lɛč'
-v:::l:::lätc̕:::doak:::lɛč':::lech':::pl. are fierce:::note:::lɛč'
-v:::l:::läkʷ:::doak:::lɛkʷ:::lekw:::be far:::note:::lɛkʷ
-v:::l:::läxʷ:::doak:::lɛxʷ(-p):::lekhw(-p):::hurt:::note:::lɛxʷ(-p)
-v:::l:::läxʷ:::doak:::lɛxʷ:::lekhw:::perforate, be hole:::note:::lɛxʷ
-v:::l:::laq̕:::doak:::laq':::laq':::search for:::note:::laq'
-v:::l:::lax̣:::doak:::lax̣:::laqh:::lighten, be electric:::note:::lax̣
-v:::l:::lax̣:::doak:::lax̣(-t):::laqh(-t):::be friend:::note:::lax̣(-t)
-v:::l:::läq̕:::doak:::lɛq':::leq':::bury:::note:::lɛq'
-v:::l:::läṛʷ:::doak:::lɛʕʷ:::le(w :::draw on, make fit:::note:::lɛʕʷ
-v:::l:::lic:::doak:::liš:::lish:::be hilly, mountain:::note:::liš
-v:::l:::li'<sup>ɩ</sup>lä'<sup>ä</sup>:::doak:::liʔlɛʔ(-t):::li'le'(-t):::pl. fly:::note:::liʔlɛʔ(-t)
-v:::l:::limt:::doak:::lim(-t):::lim(-t):::be glad, thankful, pleased:::note:::lim(-t)
-v:::l:::ligw:::doak:::ligʷ(-t):::ligw(-t):::snare, catch in trap:::note:::ligʷ(-t)
-v:::l:::lup:::doak:::lup:::lup:::be dry, thirsty:::note:::lup
-v:::l:::lut:::doak:::lut:::lut:::be mischievous, not, negative:::note:::lut
-v:::l:::luk̕ʷ:::doak:::luk'ʷ:::nluk'w:::pull, pick off strings, fuzz:::note:::luk'ʷ
-v:::ɫ:::ɬats:::doak:::ɫac:::ɫats:::one drop falls:::note:::ɫac
-v:::ɫ:::ɬapx̣:::doak:::ɫapx̣:::ɫapqh:::be slightly skinned:::note:::ɫapx̣
-v:::ɫ:::ɬay:::doak:::ɫay:::ɫay:::make dirty marks, scribble:::note:::ɫay
-v:::ɫ:::ɬaxʷ:::doak:::ɫaxʷ:::ɫakhw:::wear, draw on:::note:::ɫaxʷ
-v:::ɫ:::ɬaq:::doak:::ɫaq:::ɫaq:::be serviceberry, do with serviceberry:::note:::ɫaq
-v:::ɫ:::ɬaq:::doak:::ɫaq:::ɫaq:::mend, patch:::note:::ɫaq
-v:::ɫ:::ɬaqi'<sup>ɩ</sup>:::doak:::ɫaqiʔ:::ɫaqi':::pl. lower, fall, dismount:::note:::ɫaqiʔ
-v:::ɫ:::ɬaq̕:::doak:::ɫaq':::ɫaq':::be wide:::note:::ɫaq'
-v:::ɫ:::ɬaq̕:::doak:::ɫaq':::ɫaq':::person lies on stomach, crouch:::note:::ɫaq'
-v:::ɫ:::ɬaqʷ:::doak:::ɫaqʷ:::ɫaqw:::band used with pressure, belt:::note:::ɫaqʷ
-v:::ɫ:::ɬaqʷ:::doak:::ɫaqʷ:::ɫaqw:::store hanging, hang on line:::note:::ɫaqʷ
-v:::ɫ:::ɬaq̕ʷ:::doak:::ɫaq'ʷ:::ɫaq'w:::skin, pull off:::note:::ɫaq'ʷ
-v:::ɫ:::ɬax̣ʷ:::doak:::ɫax̣ʷ:::ɫaqhw:::move with weight and speed:::note:::ɫax̣ʷ
-v:::ɫ:::ɬax̣ʷp:::doak:::ɫax̣ʷp:::ɫaqhwp:::escape:::note:::ɫax̣ʷp
-v:::ɫ:::ɬax̣ʷp̕:::doak:::ɫax̣ʷp':::ɫaqhwp':::rush:::note:::ɫax̣ʷp'
-v:::ɫ:::ɬax̣ʷq̕:::doak:::ɫax̣ʷq':::ɫaqhwq':::foot slips:::note:::ɫax̣ʷq'
-v:::ɫ:::ɬaṛʷ:::doak:::ɫaʕʷ(u-):::ɫa(w(u-):::be slippery (as ice):::note:::ɫaʕʷ(u-)
-v:::ɫ:::ɬä'än:::doak:::ɫɛʔɛn :::ɫe'en:::be on opposite side:::note:::ɫɛʔɛn 
-v:::ɫ:::ɬäp:::doak:::ɫɛp:::ɫep:::be difficult but possible of achievement, be disgusting:::note:::ɫɛp
-v:::ɫ:::ɬäp̕:::doak:::ɫɛp'(u-):::ɫep'(u-):::be undaunted:::note:::ɫɛp'(u-)
-v:::ɫ:::reichard:::doak:::ɫɛp':::ɫep':::stripe, mark, make welt:::note:::ɫɛp'
-v:::ɫ:::ɬäm̕:::doak:::ɫɛm':::ɫe'm:::apologize:::note:::ɫɛm'
-v:::ɫ:::ɬätq̕:::doak:::ɫɛtq':::ɫetq':::splash, drops hit surface:::note:::ɫɛtq'
-v:::ɫ:::ɬät̕:::doak:::ɫɛt':::ɫet':::one jumps:::note:::ɫɛt'
-v:::ɫ:::ɬäts:::doak:::ɫɛc:::ɫets:::flat objects lie:::note:::ɫɛc
-v:::ɫ:::ɬätc̕:::doak:::ɫɛč':::ɫech':::string breaks:::note:::ɫɛč'
-v:::ɫ:::ɬäk̕ʷ:::doak:::ɫɛk'ʷ:::ɫek'w:::pierce with fine-pointed object, fork, barb, spike:::note:::ɫɛk'ʷ
-v:::ɫ:::ɬäxʷ:::doak:::ɫɛxʷ:::ɫekhw:::draw together, slip on:::note:::ɫɛxʷ
-v:::ɫ:::ɬäxʷ:::doak:::ɫɛxʷ:::ɫekhw:::sew:::note:::ɫɛxʷ
-v:::ɫ:::ɬäq̕:::doak:::ɫɛq':::ɫeq':::make impound, round up animals:::note:::ɫɛq'
-v:::ɫ:::ɬäl:::doak:::ɫɛl:::ɫel:::sprinkle:::note:::ɫɛl
-v:::ɫ:::ɬäṛʷ:::doak:::ɫɛʕ:::ɫe(:::skate, slide on ice:::note:::ɫɛʕ
-v:::ɫ:::ɬi'<sup>ɩ</sup>:::doak:::ɫiʔ:::ɫi':::be close to edge, be border:::note:::ɫiʔ
-v:::ɫ:::ɬip̕:::doak:::ɫip':::ɫip':::make striped (?):::note:::ɫip'
-v:::ɫ:::ɬit̕:::doak:::ɫit':::ɫit':::sprinkle ceremonially:::note:::ɫit'
-v:::ɫ:::ɬit̕:::doak:::ɫit':::ɫit':::pl. jump off of, out of:::note:::ɫit'
-v:::ɫ:::ɬitk̕ʷ:::doak:::ɫitk'ʷ:::ɫitk'w:::pl. objects jerk into different position:::note:::ɫitk'ʷ
-v:::ɫ:::ɬis:::doak:::ɫis:::ɫis:::measure, weigh:::note:::ɫis
-v:::ɫ:::ɬɩɬiy̕:::doak:::ɫəɫiy':::ɫɫi'y :::spotted:::note:::ɫəɫiy'
-v:::ɫ:::ɬɩɬikʷ:::doak:::ɫəɫikʷ(u-):::ɫɫikw(u-) :::be speckled, small-spotted:::note:::ɫəɫikʷ(u-)
-v:::ɫ:::ɬik̕ʷ:::doak:::ɫik'ʷ:::ɫik'w:::hairlike object breaks:::note:::ɫik'ʷ
-v:::ɫ:::ɬil:::doak:::ɫil:::ɫil:::sprinkle:::note:::ɫil
-v:::ɫ:::ɬu'<sup>u</sup>:::doak:::ɫuʔ:::ɫu':::be there near third person:::note:::ɫuʔ
-v:::ɫ:::ɬu'un:::doak:::ɫuʔum:::ɫu'um:::be in opposite direction:::note:::ɫuʔum 
-v:::ɫ:::ɬuts̕:::doak:::ɫuc':::ɫuts':::pl. sticklike objects break:::note:::ɫuc'
-v:::ɫ:::ɬukʷ:::doak:::ɫukʷ(u-):::ɫukw(u-):::be stained with blood:::note:::ɫukʷ(u-)
-v:::ɫ:::ɬuk̕ʷ:::doak:::ɫuk'ʷ:::ɫuk'w:::recall, remember:::note:::ɫuk'ʷ
-v:::ɫ:::reichard:::doak:::ɫɔmɛn':::ɫome'n:::scold:::note:::ɫɔmɛn'
-v:::ɫ:::ɬᴐmän̕:::doak:::sail:::nico:::english:::note:::
-v:::ɫ:::ɬᴐq:::doak:::sail:::nico:::english:::note:::
-v:::ɫ:::reichard:::doak:::ɫɔq':::ɫoq':::be bald, bare:::note:::ɫɔq'
-v:::l' (derivative):::l̕ɩl̕itc:::doak:::l'əl'ič:::'l'lich:::be thin slice:::note:::l'əl'ič
-v:::l' (derivative):::l̕ᴇl̕ax̣:::doak:::l'əl'ax̣:::'l'laqh:::lighten:::note:::l'əl'ax̣
-v:::ʕ/(:::ʀaw:::doak:::ʕaw:::(aw:::drop:::note:::ʕaw
-v:::ʕ/(:::ʀax̣:::doak:::ʕax̣:::(aqh:::wrap string evenly:::note:::ʕax̣
-v:::ʕ/(:::ʀäm:::doak:::ʕɛm(-t):::(em(-t):::melt, dissolve, waste away:::note:::ʕɛm(-t)
-v:::ʕ/(:::ʀäts:::doak:::ʕɛc:::(ets:::tie:::note:::ʕɛc
-v:::ʕ/(:::ʀäts̕:::doak:::ʕɛc':::(ets':::play out, wear out, become exhausted:::note:::ʕɛc'
-v:::ʕ/(:::ʀäts̕xʷ:::doak:::ʕɛc'xʷ:::(ets'khw :::be worn out, tired:::note:::ʕɛc'xʷ
-v:::ʕ/(:::ʀäts̕xʷ:::doak:::ʕɛc'xʷ:::(ets'khw :::be hungry for meat, surfeited with vegetable food:::note:::ʕɛc'xʷ
-v:::ʕ/(:::ʀäy:::doak:::ʕɛy:::(ey:::be embittered:::note:::ʕɛy
-v:::ʕ/(:::ʀäy̕:::doak:::ʕɛy':::(e'y:::be angry:::note:::ʕɛy'
-v:::ʕ/(:::ʀäl̕:::doak:::ʕɛl':::(e'l:::obstruct, cover:::note:::ʕɛl'
-v:::ʕ/(:::ʀipɩlc:::doak:::ʕipəlš:::(iplsh:::person hides:::note:::ʕipəlš
-v:::ʕ/(:::ʀid:::doak:::ʕid:::(id:::glow, become redhot:::note:::ʕid
-v:::ʕ/(:::ʀits̕:::doak:::ʕic':::(its':::be persistent, tenacious, strive:::note:::ʕic'
-v:::ʕ/(:::ʀigw:::doak:::ʕigʷ:::(igw:::throw pl. objects:::note:::ʕigʷ
-v:::ʕ/(:::ʀus:::doak:::ʕus(-t):::(us(-t):::be lost:::note:::ʕus(-t) 
-v:::ʕ/(:::ʀuy:::doak:::ʕuy:::(uy:::coax, urge:::note:::ʕuy
-v:::ʕ/(:::ʀuy:::doak:::ʕuy:::(uy:::waste, be extravagant:::note:::ʕuy
-v:::ʕ/(:::ʀuy-tct:::doak:::ʕuy-čt:::(uy-cht:::mistreat old or helpless:::note:::ʕuy-čt
-v:::ʕʷ/(w:::ṛʷax̣ʷ:::doak:::ʕʷax̣ʷ:::(waqhw:::stringlike object extends:::note:::ʕʷax̣ʷ
-v:::ʕʷ/(w:::ṛʷä'<sup>ä</sup>:::doak:::ʕʷaʔ:::(wa':::reach into:::note:::ʕʷaʔ
-v:::ʕʷ/(w:::ṛʷäm̕:::doak:::ʕʷɛm'(-t) :::(we'm(-t):::be enjoyable, wholesome:::note:::ʕʷɛm'(-t) 
-v:::ʕʷ/(w:::ṛʷäl:::doak:::ʕʷɛl:::(wel:::dunk, dip to soak:::note:::ʕʷɛl
-v:::ʕʷ/(w:::ṛʷäl-ä'<sup>ä</sup>l:::doak:::ʕʷɛl-ɛʔl:::(wel-e'l:::come to a lake:::note:::ʕʷɛl-ɛʔl
-v:::ʕʷ/(w:::ṛʷäɬ:::doak:::ʕʷɛɫ(u-):::(weɫ(u-):::be of one piece:::note:::ʕʷɛɫ(u-)
-v:::ʕʷ/(w:::ṛʷi'-ɩlc:::doak:::ʕʷi'-əlš:::(wi'-lsh:::vomit:::note:::ʕʷi'-əlš
-v:::ʕʷ/(w:::ṛʷim:::doak:::ʕʷim:::(wim:::enjoy, relish:::note:::ʕʷim
-v:::ʕʷ/(w:::ṛʷimic:::doak:::ʕʷimiš:::(wimish:::hurry on while moving:::note:::ʕʷimiš
-v:::ʕʷ/(w:::ṛʷit̕.s:::doak:::ʕʷits:::(wits:::smile, smirk:::note:::ʕʷits
-v:::h:::ha:::doak:::ha:::ha:::laugh loudly, haw-haw:::note:::ha
-v:::h:::haq:::doak:::haq:::haq:::be space:::note:::haq
-v:::h:::har:::doak:::har:::har:::snore:::note:::har
-v:::h:::hä'in̕:::doak:::hɛʔin':::he'i'n:::eight:::note:::hɛʔin'
-v:::h:::häp:::doak:::hɛp:::hep:::gobble:::note:::hɛp
-v:::h:::hän:::doak:::hɛn:::hen:::be grayish in color:::note:::hɛn
-v:::h:::häṛʷ:::doak:::hɛʕʷ:::he(w:::growl like bear:::note:::hɛʕʷ
-v:::h:::hitcä'<sup>ä</sup>:::doak:::hičɛʔ:::hiche':::where?:::note:::hičɛʔ
-v:::h:::hᴐi:::doak:::hɔi:::hoi:::cease:::note:::hɔi
-v:::h:::hṛʷh:::doak:::hʕʷh:::h(wh:::frighten:::note:::hʕʷh
-aci:::a:::aˑˑˑ:::doak:::a···:::a···:::with rising tone, oh!:::note:::a···
-aci:::a:::aˑˑˑ:::doak:::a···:::a···:::with even tone, disapproval:::note:::a···
-aci:::a:::ax̣iw̕ɬ:::doak:::ax̣iw'ɫ:::aqhi'wɫ:::now, today:::note:::ax̣iw'ɫ
-aci:::a:::uts̕-ax̣íɬ:::doak:::uc'-ax̣íɫ:::uts'-aqh<u>i</u>ɫ:::because:::note:::uc'-ax̣íɫ
-aci:::a:::äy̕níɬ:::doak:::sail:::nico:::english:::note:::
-aci:::a:::pintc or pinttc:::doak:::pinč or pintč:::pinch:::always:::note:::pinč or pintč
-aci:::a:::p̕unal̕:::doak:::p'unal':::p'una'l:::at least:::note:::p'unal'
-aci:::a:::mäl̕:::doak:::mɛl':::me'l:::on near, touching, in addition to:::note:::mɛl'
-aci:::a:::miyäɬ:::doak:::miyɛɫ:::miyeɫ:::too, very:::note:::miyɛɫ
-aci:::a:::wax̣ᴇm:::doak:::wax̣əm':::waqh'm:::I told you so:::note:::wax̣əm'
-aci:::a:::wihu'<sup>u</sup>:::doak:::wihuʔ:::wihu':::short distance:::note:::wihuʔ
-aci:::a:::w̕ämnús:::doak:::w'ɛmnús:::'wemn<u>u</u>s:::in vain, useless:::note:::w'ɛmnús
-aci:::a:::w̕im̕:::doak:::w'im':::'wi'm:::very near, almost:::note:::w'im'
-aci:::a:::dä'äɬ:::doak:::dɛʔɛɫ:::de'eɫ:::exceptionally, surprisingly:::note:::dɛʔɛɫ
-aci:::a:::tᴇmíc:::doak:::tɛmíš:::tem<u>i</u>sh:::just, only:::note:::tɛmíš
-aci:::a:::twä:::doak:::twɛ:::twe:::with:::note:::twɛ
-aci:::a:::tqilttc:::doak:::tqiltč:::tqiltch:::inland (hence east):::note:::tqiltč
-aci:::a:::nä<sup>ä</sup>m̕n̕us:::doak:::nɛm'n'us:::ne'm'nus:::I don't know:::note:::nɛm'n'us
-aci:::a:::tsa'<sup>a</sup>x̣alp̕út:::doak:::caʔx̣alp'út:::tsa'qhalp'<u>u</u>t:::what's the use! (a very mean word):::note:::caʔx̣alp'út
-aci:::a:::tsmi'<sup>ɩ</sup>:::doak:::cmiʔ:::tsmi':::it was to be but is not:::note:::cmiʔ
-aci:::a:::an-caricíɬ:::doak:::an-šarišíɫ:::an-sharish<u>i</u>ɫ:::upstream:::note:::an-šarišíɫ
-aci:::a:::ci'<sup>ɩ</sup>mic:::doak:::šiʔmiš:::shi'mish:::anywhere, at random:::note:::šiʔmiš
-aci:::a:::tcᴇn̕:::doak:::čən':::ch'n:::interrogative:::note:::čən'
-aci:::a:::tc̕am̕:::doak:::č'am':::ch'a'm:::just:::note:::č'am'
-aci:::a:::yäm-p:::doak:::yɛm-p:::yem-p:::forever:::note:::yɛm-p
-aci:::a:::kum̕:::doak:::kum':::ku'm:::and:::note:::kum'
-aci:::a:::kukúkʷ:::doak:::kukúkʷ:::kuk<u>u</u>kw:::in the other room:::note:::kukúkʷ
-aci:::a:::kʷɩm̕ɬ:::doak:::kʷəm'ɫ:::kw'mɫ:::immediately:::note:::kʷəm'ɫ
-aci:::a:::k̕ʷnä'<sup>ä</sup>:::doak:::k'ʷnɛʔ:::k'wne':::future:::note:::k'ʷnɛʔ
-aci:::a:::k̕uk̕ʷníy̕ä'<sup>ä</sup>:::doak:::k'uk'ʷn'íy'ɛʔ:::k'uk'w'n<u>i</u>'ye':::in a short while:::note:::k'uk'ʷn'íy'ɛʔ
-aci:::a:::k̕uk̕ʷi'<sup>ɩ</sup>ɬ:::doak:::k'uk'ʷiʔɫ :::k'uk'wi'ɫ:::in a short time:::note:::k'uk'ʷiʔɫ 
-aci:::a:::xʷa'aɬ:::doak:::xʷaʔaɫ:::khwa'aɫ:::almost:::note:::xʷaʔaɫ
-aci:::a:::xʷɩstc̕i:::doak:::xʷəč'i:::khwch'i:::interjection of admiration "how nice it is!":::note:::xʷəč'i
-aci:::a:::x̣umút:::doak:::x̣umút:::qhum<u>u</u>t:::of course, I suppose:::note:::x̣umút
-aci:::a:::x̣ämä'<sup>ä</sup>tc:::doak:::x̣ɛ́mɛʔč:::qh<u>e</u>me'ch:::just you dare!:::note:::x̣ɛ́mɛʔč
-aci:::a:::x̣äl:::doak:::x̣ɛl:::qhel:::also, likewise:::note:::x̣ɛl
-aci:::a:::x̣älä'<sup>ä</sup>:::doak:::x̣ɛlɛʔ:::qhele':::might, used in sense of expecting something unfavorable:::note:::x̣ɛlɛʔ
-aci:::a:::x̣iɬ:::doak:::x̣iɫ:::qhiɫ:::might, used in sense of possibility of any kind:::note:::x̣iɫ
-aci:::a:::ɬ:::doak:::ɫ:::ɫ:::connective:::note:::ɫ
-aci:::a:::ɬuw̕ä:::doak:::ɫuw'ɛ:::ɫu'we:::that near third person or remote:::note:::ɫuw'ɛ
-aci:::a:::ɬᴐqʷ:::doak:::ɫɔqʷ:::ɫoqw:::and also:::note:::ɫɔqʷ
-aci:::a:::hɩɬ:::doak:::həɫ:::hɫ:::general connective:::note:::həɫ
-n:::a:::*a<sup>a</sup>pᴐˊtar:::doak:::apótar:::ap<u>o</u>tar:::apostle:::note:::apótar
-n:::a:::*apls:::doak:::apls:::apls:::apple:::note:::apls
-n:::a:::*anc:::doak:::anš:::ansh:::angel:::note:::anš
-n:::a:::asqʷ:::doak:::asqʷ:::asqw:::son:::note:::asqʷ
-n:::a:::atcatcn-áɬqʷ:::doak:::ačačn-áɫqʷ:::achachn-<u>a</u>ɫqw:::juniper:::note:::ačačn-áɫqʷ
-n:::a:::ay̕x̣:::doak:::ay'x̣:::a'yqh:::crayfish:::note:::ay'x̣
-n:::a:::y̕-alstq:::doak:::y'-alstq:::'y-alstq:::summer:::note:::y'-alstq
-n:::a:::aɬdáräntc:::doak:::aɫdárɛnč:::aɫd<u>a</u>rench:::month, sun:::note:::aɫdárɛnč
-n:::a:::aɬq̕íts̕äntc:::doak:::aɫq'íc'ɛnč:::aɫq'<u>i</u>ts'ench:::snake:::note:::aɫq'íc'ɛnč
-n:::a:::aɬq̕ʷäˊt̕ut:::doak:::aɫq'ʷɛ́t'ut:::aɫq'w<u>e</u>t'ut:::Plummer (place name):::note:::aɫq'ʷɛ́t'ut
-n:::ɛ/e:::*äijíp:::doak:::ɛiji'p:::eiji'p:::Egypt:::note:::ɛiji'p
-n:::ɛ/e:::ätx̣ʷä'<sup>ä</sup>:::doak:::ɛtx̣ʷɛʔ:::etqhwe':::camas:::note:::ɛtx̣ʷɛʔ
-n:::ɛ/e:::atcs-ät̕qᴇt:::doak:::sail:::nico:::english:::note:::
-n:::ɛ/e:::ästcítcä'<sup>ä</sup>:::doak:::ačs-ɛt'qət:::achs-et'qt:::day time:::note:::ačs-ɛt'qət
-n:::ɛ/e:::reichard:::ɛsčíčɛʔ:::ɛsčíčɛʔ:::esch<u>i</u>che':::horse, pet, domestic animal:::note:::ɛsčíčɛʔ
-n:::ɛ/e:::äɬṛʷäts̕:::doak:::ɛɫʕʷɛc':::eɫ(wets':::magpie:::note:::ɛɫʕʷɛc'
-n:::i:::i'i:::doak:::iʔi:::i'i:::turtledove:::note:::iʔi
-n:::i:::ík̕ʷul:::doak:::i'k'ʷul:::i'k'wul:::fish roe:::note:::i'k'ʷul
-n:::i:::ä'íxʷä'<sup>ä</sup>:::doak:::ɛʔíxʷɛʔ:::e'<u>i</u>khwe':::mother's sister (dim.):::note:::ɛʔíxʷɛʔ
-n:::i:::iltc:::doak:::ilč:::ilch:::kinnikinnick berry:::note:::ilč
-n:::u, ɔ/o:::tcs-ups:::doak:::čs-ups:::chs-ups:::tail:::note:::čs-ups
-n:::u, ɔ/o:::usä'<sup>ä</sup>:::doak:::usɛʔ:::use':::egg:::note:::usɛʔ
-n:::u, ɔ/o:::tc̕i<sup>ɩ</sup>y̕-úkʷä'<sup>ä</sup>:::doak:::č'iy'-úkʷɛʔ:::ch'i'y-<u>u</u>kwe':::w.s. younger brother:::note:::č'iy'-úkʷɛʔ
-n:::u, ɔ/o:::*buˑlɩˑ:::doak:::bu·lə·:::bu·l·:::bull:::note:::bu·lə·
-n:::u, ɔ/o:::*s-pa<sup>a</sup>yᴐˊlụmc:::doak:::s-payóləmš:::s-pay<u>o</u>lmsh:::Spanish:::note:::s-payóləmš
-n:::u, ɔ/o:::s-pápx̣-ɬtsä'<sup>ä</sup>:::doak:::s-pápx̣-ɫc'ɛʔ:::s-p<u>a</u>pqh-ɫts'e':::ermine:::note:::s-pápx̣-ɫc'ɛʔ
-n:::u, ɔ/o:::*patáq:::doak:::patáq:::pat<u>a</u>q:::potato:::note:::patáq
-n:::u, ɔ/o:::päˊwpu'ɩc:::doak:::pɛ́wpuʔəš:::p<u>e</u>wpu'sh:::tin oil can:::note:::pɛ́wpuʔəš
-n:::u, ɔ/o:::s-päˊtäp:::doak:::s-pɛ́tɛp:::s-p<u>e</u>tep:::small gopher:::note:::s-pɛ́tɛp
-n:::u, ɔ/o:::pätstcɩlä:::doak:::pɛcčəlɛ:::petschle:::leaf, cabbage:::note:::pɛcčəlɛ
-n:::u, ɔ/o:::päkut:::doak:::pɛkut:::pekut:::skin, hide:::note:::pɛkut
-n:::u, ɔ/o:::päxpụxʷ:::doak:::pɛxpəxʷ:::pekhpkhw:::pekhpkhw:::note:::pɛxpəxʷ
-n:::u, ɔ/o:::pípä'<sup>ä</sup>:::doak:::pípɛʔ:::p<u>i</u>pe':::father:::note:::pípɛʔ
-n:::u, ɔ/o:::*piwyä:::doak:::piwyɛ:::piwye:::camas of Nez Perce country:::note:::piwyɛ
-n:::u, ɔ/o:::s-pinttc:::doak:::s-pintč:::s-pintch:::year:::note:::s-pintč
-n:::u, ɔ/o:::pítsä'<sup>ä</sup>:::doak:::pícɛʔ:::p<u>i</u>tse':::root digger:::note:::pícɛʔ
-n:::u, ɔ/o:::s-pítcs-mᴇn:::doak:::s-píčs-mən:::s-p<u>i</u>chs-mn:::pestle:::note:::s-píčs-mən
-n:::u, ɔ/o:::s-píläm:::doak:::s-pílɛm:::s-p<u>i</u>lem:::level land:::note:::s-pílɛm
-n:::u, ɔ/o:::its-pu'<sup>u</sup>:::doak:::ic-puʔs:::its-pu's:::desire, heart:::note:::ic-puʔs
-n:::u, ɔ/o:::s-pum:::doak:::s-pum:::s-pum:::fur, feathers (on animal):::note:::s-pum
-n:::u, ɔ/o:::s-puɬt:::doak:::s-puɫt:::s-puɫt:::feathers (loose):::note:::s-puɫt
-n:::u, ɔ/o:::pul̕yä:::doak:::pul'yɛ:::pu'lye:::gopher:::note:::pul'yɛ
-n:::u, ɔ/o:::pulya<sup>a</sup>hal̕:::doak:::pulyahal':::pulyaha'l:::mole:::note:::pulyahal'
-n:::u, ɔ/o:::s-pᴐtst:::doak:::s-pɔtc:::s-potts:::scab, sore, excrement:::note:::s-pɔtc
-n:::u, ɔ/o:::pᴐˊl-pᴐlq-ᴇn:::doak:::pól-pɔlq-ən:::p<u>o</u>l-polq-n:::thimbleberry:::note:::pól-pɔlq-ən
-n:::u, ɔ/o:::s-pɩt̕áswäl:::doak:::s-pət'áswɛl:::s-pt'<u>a</u>swel:::trout:::note:::s-pət'áswɛl
-n:::u, ɔ/o:::s-pᴇtw̕ínuxʷ:::doak:::s-pətw'ínuxʷ:::s-pt'w<u>i</u>nukhw:::head of a nest, brood, house-hold:::note:::s-pətw'ínuxʷ
-n:::u, ɔ/o:::s-pᴇsáiyä:::doak:::s-pəsáiyɛ:::s-ps<u>a</u>iye:::folly, error:::note:::s-pəsáiyɛ
-n:::u, ɔ/o:::*pus:::doak:::pus:::pus:::cat:::note:::pus
-n:::u, ɔ/o:::púsä'<sup>ä</sup>:::doak:::púsɛʔ:::p<u>u</u>se':::father's brother:::note:::púsɛʔ
-n:::p':::s-p̕an̕x̣:::doak:::s-p'an'x̣:::s-p'a'nqh:::woven bag:::note:::s-p'an'x̣
-n:::p':::s-p̕árk̕ʷ-alqs:::doak:::s-p'árk' w-alqs:::s-p'<u>a</u>rk':::turtle, pulley:::note:::s-p'árk' w-alqs
-n:::p':::p̕ästa:::doak:::p'ɛsta:::p'esta:::snipe:::note:::p'ɛsta
-n:::p':::p̕ästä'<sup>ä</sup>:::doak:::p'ɛstɛʔ:::p'este':::nighthawk:::note:::p'ɛstɛʔ
-n:::p':::p̕ätc̕ᴇn̕:::doak:::p'ɛč'ən':::p'ech''n:::lynx:::note:::p'ɛč'ən'
-n:::p':::p̕äˊkʷlä'<sup>ä</sup>:::doak:::p'ɛ́kʷleʔ:::p'<u>e</u>kwle':::ball:::note:::p'ɛ́kʷleʔ
-n:::p':::s-p̕äˊxʷ-äntc:::doak:::s-p'ɛ́xʷ-ɛnč:::s-p'<u>e</u>khw-ench:::hog fennel root:::note:::s-p'ɛ́xʷ-ɛnč
-n:::p':::s-p̕ít̕äm:::doak:::s-p'ít'ɛm:::s-p'<u>i</u>t'em:::bitterroot:::note:::s-p'ít'ɛm
-n:::p':::s-p̕í-ɬts̕ä'<sup>ä</sup>:::doak:::s-p'í-ɫc'ɛʔ:::s-p'<u>i</u>-ɫts'e':::elk:::note:::s-p'í-ɫc'ɛʔ
-n:::m:::matus:::doak:::matus:::matus:::camas (piwyɛ) mush:::note:::matus
-n:::m:::masmᴇs:::doak:::masmɛs:::masmes:::a plant which smells awful when boiling:::note:::masmɛs
-n:::m:::máts̕-uɬt:::doak:::mác'-uɫt:::m<u>a</u>ts'-uɫt:::pus:::note:::mác'-uɫt
-n:::m:::mats̕p:::doak:::mac'p:::mats'p:::bee, wasp:::note:::mac'p
-n:::m:::s-max̣í'<sup>ɩ</sup>tcn̕:::doak:::s-max̣íʔčn':::s-maqh<u>i</u>'ch'n:::grizzly bear:::note:::s-max̣íʔčn'
-n:::m:::malqänúps:::doak:::malqɛnúps:::malqen<u>u</u>ps:::golden eagle:::note:::malqɛnúps
-n:::m:::s-málq-ᴇn:::doak:::s-málq-ən:::s-m<u>a</u>lq-n:::cooked black moss:::note:::s-málq-ən
-n:::m:::mimc or minc:::doak:::mimš or minš:::mimsh:::box:::note:::mimš
-n:::m:::mít̕t̕c̕ädä'<sup>ä</sup>:::doak:::mit'č'ɛdɛʔ:::mit'ch'ede':::blood:::note:::mit'č'ɛdɛʔ
-n:::m:::minátcalqs:::doak:::mináčalqs:::min<u>a</u>chalqs:::buzzard:::note:::mináčalqs
-n:::m:::s-míy̕äm:::doak:::s-míy'ɛm:::s-m<u>i</u>'yem:::woman, wife:::note:::s-míy'ɛm
-n:::m:::mul:::doak:::mul:::mul:::butter:::note:::mul
-n:::m:::hɩn-múlcäntc:::doak:::hən-múlšenč:::hn-m<u>u</u>lshench:::beaver:::note:::hən-múlšenč
-n:::m:::s-mul̕-mᴇn:::doak:::s-mul'-mən:::s-mu'l-mn:::war spear:::note:::s-mul'-mən
-n:::m:::*muh:::doak:::muh:::muh:::cow:::note:::muh
-n:::m:::mᴐˊt̕us:::doak:::mót'us:::m<u>o</u>t'us:::kidney:::note:::mót'us
-n:::m:::ä-sɩn-mɩsmɩs-íw̕äs:::doak:::ɛ-sən-məsməs-íw'ɛs:::e-sn-msms-<u>i</u>'wes:::yew-wood, heart of yew, bow-wood:::note:::ɛ-sən-məsməs-íw'ɛs
-n:::m:::s-mɩyíw:::doak:::s-məyíw:::s-my<u>i</u>w:::coyote:::note:::s-məyíw
-n:::m:::s-mɩɬítc:::doak:::s-məɫíč:::s-mɫ<u>i</u>ch:::salmon:::note:::s-məɫíč
-n:::m:::s-m̕äˊ<sup>ä</sup>m̕ín̕äp:::doak:::s-m'ɛʔm'ín'ɛp:::s-'me'm<u>i</u>'nep:::toad:::note:::s-m'ɛʔm'ín'ɛp
-n:::m:::m̕äl̕ä:::doak:::m'ɛl'ɛ:::'me'le:::bait:::note:::m'ɛl'ɛ
-n:::m:::s-m̕-m̕útscᴇn:::doak:::s-m'-m'úcšən':::s-'m-'m<u>u</u>tssh'n:::female animal, mare:::note:::s-m'-m'úcšən'
-n:::m:::s-wa'ítn̕:::doak:::s-waʔítn':::s-wa'<u>i</u>t'n:::spring of water:::note:::s-waʔítn'
-n:::m:::wáx̣-iɬp:::doak:::wáx̣-iɫp:::w<u>a</u>qh-iɫp:::dogwood:::note:::wáx̣-iɫp
-n:::w, w':::wartc:::doak:::warč:::warch:::frog:::note:::warč
-n:::w, w':::wä'<sup>ä</sup>wi'ítc:::doak:::wɛʔwiʔíč:::we'wi'<u>i</u>ch:::whippoorwill:::note:::wɛʔwiʔíč
-n:::w, w':::wäsx̣ax̣:::doak:::wɛsx̣ax̣:::wesqhaqh:::robin:::note:::wɛsx̣ax̣
-n:::w, w':::wähíma':::doak:::wɛhíma':::weh<u>i</u>ma':::Nez Perce people and country:::note:::wɛhíma'
-n:::w, w':::s-wiwaláqᴇn:::doak:::s-wiwaláqən:::s-wiwal<u>a</u>qn:::Whispering-in-branches (place-name):::note:::s-wiwaláqən
-n:::w, w':::wicú'us:::doak:::wišúʔus:::wish<u>u</u>'us:::black-tailed deer:::note:::wišúʔus
-n:::w, w':::wᴐptú:::doak:::wɔptú:::wopt<u>u</u>:::potatoes that grow in Yakima and Nez Perce country:::note:::wɔptú
-n:::w, w':::wụlwụlím:::doak:::wəlwəlím:::wlwl<u>i</u>m:::money, valuables:::note:::wəlwəlím
-n:::w, w':::s-w̕a'<sup>a</sup>:::doak:::s-w'aʔ:::s-'wa':::cougar:::note:::s-w'aʔ
-n:::w, w':::w̕ụl̕w̕ụl̕ím̕:::doak:::w'əlw'əl'ím:::'w'lw'l<u>i</u>m:::iron, knife:::note:::w'əlw'əl'ím
-n:::d:::däˊctcägwä:::doak:::dɛ́ščɛgʷɛ:::d<u>e</u>shchegwe:::husband's brother, sister's husband:::note:::dɛ́ščɛgʷɛ
-n:::d:::däɬ-äɬp:::doak:::dɛɫ-ɛɫp:::deɫ-eɫp:::poplar:::note:::dɛɫ-ɛɫp
-n:::d:::dᴇ-däl̕dᴇl̕:::doak:::də-dɛ́l'dəl':::d-d<u>e</u>'ld'l:::bush (dim.):::note:::də-dɛ́l'dəl'
-n:::d:::däˊl̕-äɬp:::doak:::dɛ́l'-əɫp:::d<u>e</u>'l-ɫp:::willow tree:::note:::dɛ́l'-əɫp
-n:::d:::tc-däl̕-díl̕p:::doak:::č-dɛl'-díl'p:::ch-de'l-d<u>i</u>'lp:::bat, chickenhawk:::note:::č-dɛl'-díl'p
-n:::d:::s-dílu':::doak:::s-dílu:::s-d<u>i</u>lu:::switch:::note:::s-dílu
-n:::d:::dupᴇn:::doak:::dupən:::dupn:::lasso:::note:::dupən
-n:::d:::dúmtsᴇn:::doak:::dúmcən:::d<u>u</u>mtsn:::relative-friend:::note:::dúmcən
-n:::d:::dúɬduɬp:::doak:::dúɫduɫp:::d<u>u</u>ɫduɫp :::trees of the poplar family:::note:::dúɫduɫp
-n:::d:::dɩmínä'<sup>ä</sup>:::doak:::dəmínɛʔ:::dm<u>i</u>ne':::nest:::note:::dəmínɛʔ
-n:::t:::s-tax̣-täˊx̣-al̕tct:::doak:::s-tax̣-tɛ́x̣-al'čt:::s-taqh-t<u>e</u>qh-a'lcht:::doll:::note:::s-tax̣-tɛ́x̣-al'čt
-n:::t:::tᴇtaqʷ:::doak:::tətaqʷ:::ttaqw:::gulch, hollow:::note:::tətaqʷ
-n:::t:::s-taräˊq-cᴇn:::doak:::s-tarɛ́q-šən:::s-tar<u>e</u>q-shn:::mudhen:::note:::s-tarɛ́q-šən
-n:::t:::s-tä<sup>ä</sup>m-ílgwäs:::doak:::s-tɛm-ílgʷɛs:::s-tem-<u>i</u>lgwes:::relative:::note:::s-tɛm-ílgʷɛs
-n:::t:::sɩn-tä'úl̕ụmc:::doak:::sən-tɛʔúləmš:::sn-te'<u>u</u>lmsh:::Spokane:::note:::sən-tɛʔúləmš
-n:::t:::s-täˊpax̣ʷ:::doak:::s-tɛ́pax̣ʷ:::s-t<u>e</u>paqhw:::saliva:::note:::s-tɛ́pax̣ʷ
-n:::t:::s-tc-täm̕p:::doak:::s-č-tɛm'p:::s-ch-te'mp:::cloud:::note:::s-č-tɛm'p
-n:::t:::s-tälᴇm:::doak:::s-təɫəm:::s-tɫm:::boat:::note:::s-təɫəm
-n:::t:::s-ti'<sup>ɩ</sup>:::doak:::s-tiʔ:::s-ti':::thing:::note:::s-tiʔ
-n:::t:::s-tim̕:::doak:::s-tim':::s-ti'm:::what, something:::note:::s-tim'
-n:::t:::tiwun-ɬtsäˊ<sup>ä</sup>  [sic]:::doak:::tiwun-ɫcɛ:::tiwun-ɫts<u>e</u>:::doe:::note:::tiwun-ɫcɛ
-n:::t:::tíwämᴇn:::doak:::tíwɛmən:::t<u>i</u>wemn:::plaything of tallow (tiw indulge):::note:::tíwɛmən
-n:::t:::tintc:::doak:::tinč:::tinch:::sinew, muscle:::note:::tinč
-n:::t:::s-titctsxʷ:::doak:::s-tičcsxʷ:::s-tichtsskhw:::red willowberry (?)(colloquial translation):::note:::s-tičcsxʷ
-n:::t:::tikʷä'<sup>ä</sup>:::doak:::tikʷɛʔ:::tikwe':::father's sister:::note:::tikʷɛʔ
-n:::t:::tíxʷtstc:::doak:::tixʷcč:::tikhwtsch:::tongue:::note:::tixʷcč
-n:::t:::túpän̕:::doak:::túpɛn':::t<u>u</u>pe'n:::spider:::note:::túpɛn'
-n:::t:::tụm:::doak:::təm:::tm:::corpse, dead:::note:::təm
-n:::t:::s-tum̕c:::doak:::s-tum'š:::s-tu'msh:::friend (used by Coyote and Fox only):::note:::s-tum'š
-n:::t:::tunc:::doak:::tunš:::tunsh:::m.s. sister's child, brother's child:::note:::tunš
-n:::t:::tᴐt:::doak:::tɔt:::tot:::pet animal:::note:::tɔt
-n:::t:::tᴇmᴐˊl̕x̣:::doak:::təmól'x̣:::tm<u>o</u>'lqh:::hail:::note:::təmól'x̣
-n:::t:::tɩtw̕it:::doak:::tətw'it :::tt'wit:::youth, young boy:::note:::tətw'it 
-n:::t:::s-tiyítc-cᴇn:::doak:::s-tiyíč-šən:::s-tiy<u>i</u>ch-shn:::killdeer:::note:::s-tiyíč-šən
-n:::t:::tɩtm̕ixʷ:::doak:::tətm'ixʷ:::tt'mikhw:::animal:::note:::tətm'ixʷ
-n:::t:::twi'<sup>ɩ</sup>:::doak:::twiʔ:::twi':::the poor thing!:::note:::twiʔ
-n:::t:::tqᴇmíc:::doak:::tqəmíš:::tqm<u>i</u>sh:::snowbird (?):::note:::tqəmíš
-n:::t:::tʀin:::doak:::tʕin:::t(in:::antelope:::note:::tʕin
-n:::t':::t̕aqt̕ítcn:::doak:::t'aqt'íčn:::t'aqt'<u>i</u>chn:::game, kill:::note:::t'aqt'íčn
-n:::t':::t̕ᴇt̕aqʷín̕:::doak:::t'ət'aqʷín':::t't'aqw<u>i</u>'n:::one of the snipes:::note:::t'ət'aqʷín'
-n:::t':::s-t̕árt̕ari'<sup>ɩ</sup>m:::doak:::s-t'árt'ariʔm:::s-t'<u>a</u>rt'ari'm:::thunder (perhaps his name):::note:::s-t'árt'ariʔm
-n:::t':::t̕ä'<sup>ä</sup>kʷílc:::doak:::t'ɛʔkʷílš:::t'e'kw<u>i</u>lsh:::shaman:::note:::t'ɛʔkʷílš
-n:::t':::s-t̕ädä'<sup>ä</sup>:::doak:::s-t'ɛdɛʔ:::s-t'ede':::hay, grass, fodder:::note:::s-t'ɛdɛʔ
-n:::t':::t̕ädä'<sup>ä</sup>:::doak:::t'ɛdɛʔ:::t'ede':::canoe:::note:::t'ɛdɛʔ
-n:::t':::t̕äˊtc̕tɩtc̕:::doak:::tɛ́č'təč':::t<u>e</u>ch'tch':::blackbird:::note:::tɛ́č'təč'
-n:::t':::s-t̕iitc̕ɩmíc:::doak:::s-t'iičəmíš:::s-t'iichm<u>i</u>sh:::Virgin Mary:::note:::s-t'iičəmíš
-n:::t':::s-t̕tím-tcä'<sup>ä</sup>:::doak:::s-t'tím-čɛʔ:::s-t't<u>i</u>m-che':::daughter:::note:::s-t'tím-čɛʔ
-n:::t':::t̕ínä'<sup>ä</sup>:::doak:::t'ínɛʔ:::t'<u>i</u>ne':::outer ear:::note:::t'ínɛʔ
-n:::t':::t̕its̕:::doak:::t'ic':::t'its':::gum:::note:::t'ic'
-n:::t':::s-t̕íy-äɬtsä'<sup>ä</sup>:::doak:::s-t'íy-ɛɫcɛʔ:::s-t'<u>i</u>y-eɫtse':::caribou:::note:::s-t'íy-ɛɫcɛʔ
-n:::t':::t̕úpyä'<sup>ä</sup>:::doak:::t'úpyɛʔ:::t'<u>u</u>pye':::great grandfather:::note:::t'úpyɛʔ
-n:::t':::s-t̕únɬts̕ä'<sup>ä</sup>:::doak:::s-t'únɫc'ɛʔ:::s-t'<u>u</u>nɫts'e':::mule deer:::note:::s-t'únɫc'ɛʔ
-n:::t':::t̕us:::doak:::t'us:::t'us:::marrow:::note:::t'us
-n:::t':::tc-t̕uxʷäˊ'us:::doak:::č-t'uxʷɛ́ʔus:::ch-t'ukhw<u>e</u>'us:::fat around stomach of animal:::note:::č-t'uxʷɛ́ʔus
-n:::t':::t̕uxʷän:::doak:::t'uxʷɛn:::t'ukhwen:::jointgrass:::note:::t'uxʷɛn
-n:::t':::s-t̕ᴐpqs:::doak:::s-t'ɔpqs:::s-t'opqs:::thread:::note:::s-t'ɔpqs
-n:::t':::an-t̕ᴇl̕ánä'<sup>ä</sup>:::doak:::an-t'əl'ánɛʔ:::an-t''l<u>a</u>ne':::wolf:::note:::an-t'əl'ánɛʔ
-n:::t':::hɩn-t̕ụk̕w̕í'<sup>ɩ</sup>sen [sic]:::doak:::hən-t'ək'ʷ'-íʔsen:::hn-t'k'w-<u>i</u>'sen:::seed, pit:::note:::hən-t'ək'ʷ'-íʔsen
-n:::t':::s-t̕am̕á (ltụmc):::doak:::s-t'am'á:::s-t'a'm<u>a</u>:::(ltəmš) cow:::note:::s-t'am'á
-n:::n:::nasx̣á'ax̣:::doak:::nasx̣áʔax̣:::nasqh<u>a</u>'aqh:::m.s. father-in-law:::note:::nasx̣áʔax̣
-n:::n:::nadjarᴐˊ:::doak:::naǰaró:::najar<u>o</u>:::scoundrel, rascal:::note:::naǰaró
-n:::n:::naryä:::doak:::naryɛ:::narye:::great great grandparent:::note:::naryɛ
-n:::n:::näɬtsítc:::doak:::nɛɫcíč:::nɛɫcíč:::m.s. mother-in-law:::note:::nɛɫcíč
-n:::n:::s-nínä'<sup>ä</sup>:::doak:::s-nínɛʔ:::s-n<u>i</u>ne':::owl:::note:::s-nínɛʔ
-n:::n:::s-nitc̕-ɬxʷ:::doak:::s-nič'-ɫxʷ:::s-nich'-ɫkhw:::son-in-law (nič' cut; -lxʷ house):::note:::s-nič'-ɫxʷ
-n:::n:::núnä'<sup>ä</sup>:::doak:::núnɛʔ:::n<u>u</u>ne':::mother:::note:::núnɛʔ
-n:::n:::s-nᴐs:::doak:::s-nɔs:::s-nos:::snot:::note:::s-nɔs
-n:::n:::nᴐx̣nᴐx̣:::doak:::nɔx̣nɔx̣:::noqhnoqh:::spouse:::note:::nɔx̣nɔx̣
-n:::s:::sättc:::doak:::sɛtč:::setch:::paunch:::note:::sɛtč
-n:::s:::*sanpiyär:::doak:::sanpiyɛr:::sanpiyer:::St. Peter:::note:::sanpiyɛr
-n:::s:::*sanpᴐl:::doak:::sanpɔl:::sanpol:::St. Paul:::note:::sanpɔl
-n:::s:::*santiglis:::doak:::santiglis:::santiglis:::Holy Church:::note:::santiglis
-n:::s:::sáx̣ʷ-ɬkʷä'<sup>ä</sup>:::doak:::sáxʷ-ɫkʷɛʔ:::s<u>a</u>khw-ɫkwe':::vein:::note:::sáxʷ-ɫkʷɛʔ
-n:::s:::sarkʷs:::doak:::sarkʷs:::sarkws:::pine-squirrel:::note:::sarkʷs
-n:::s:::sar̕ítcn̕:::doak:::sar'íčn':::sa'r<u>i</u>ch'n:::squirrel:::note:::sar'íčn'
-n:::s:::atc-sät̕qᴇt:::doak:::ač-sɛt'qət:::ach-set'qt:::time:::note:::ač-sɛt'qət
-n:::s:::hɩn-sätc̕-ᴇntɩs:::doak:::hən-sɛč'-əntəs:::hn-sech'-nts:::river:::note:::hən-sɛč'-əntəs
-n:::s:::sätc̕-ätct:::doak:::sɛč'-ɛčt:::sech'-echt:::black moss (raw):::note:::sɛč'-ɛčt
-n:::s:::si'<sup>ɩ</sup>stᴇm:::doak:::siʔstəm:::si'stm:::m.s. brother's wife, wife's sister:::note:::siʔstəm
-n:::s:::sípᴇm:::doak:::sípəm:::s<u>i</u>pm:::daughter-in-law:::note:::sípəm
-n:::s:::sisí'<sup>ɩ</sup>:::doak:::sisíʔ:::sis<u>i</u>':::brother's brother (dim.):::note:::sisíʔ
-n:::s:::siw̕s:::doak:::siw's:::si'ws:::groundhog, prairie dog:::note:::siw's
-n:::s:::sit, sítkʷ:::doak:::sit, sítkʷ:::sit, s<u>i</u>tkw:::winter:::note:::sit, sítkʷ
-n:::s:::sítqaps:::doak:::sítqaps:::s<u>i</u>tqaps:::spring season:::note:::sítqaps
-n:::s:::sittc:::doak:::sitč:::sitch:::belly:::note:::sitč
-n:::s:::sintsä'<sup>ä</sup>:::doak:::sincɛʔ:::sintse':::m.s younger brother:::note:::sincɛʔ
-n:::s:::sitc̕:::doak:::sič':::sich':::ground squirrel:::note:::sič'
-n:::s:::siyᴐˊl-alqʷ:::doak:::siyól-alqʷ:::siy<u>o</u>l-alqw:::stick:::note:::siyól-alqʷ
-n:::s:::sikʷä'<sup>ä</sup>:::doak:::sikʷɛʔ:::sikwe':::water:::note:::sikʷɛʔ
-n:::s:::silä'<sup>ä</sup>:::doak:::silɛʔ:::sile':::mother's father:::note:::silɛʔ
-n:::s:::su<sup>u</sup>yäˊpụmc:::doak:::suyɛ́pəmš:::suy<u>e</u>pmsh:::white man:::note:::suyɛ́pəmš
-n:::s:::sut̕ä'<sup>ä</sup>sút̕ä:::doak:::sut'ɛʔsút'ɛ:::sut'e's<u>u</u>t'e:::rubber:::note:::sut'ɛʔsút'ɛ
-n:::s:::susᴇn̕:::doak:::susən':::sus'n:::spoon:::note:::susən'
-n:::s:::suxʷ-änäy̕:::doak:::suxʷ-ɛnɛy':::sukhw-ene'y:::rice, ant:::note:::suxʷ-ɛnɛy'
-n:::s:::*sᴐltäs:::doak:::sɔltɛs:::soltes:::soldier:::note:::sɔltɛs
-n:::c/ts:::s-tsá'aqʷ:::doak:::s-cáʔaqʷ:::s-ts<u>a</u>'aqw:::fall, autumn:::note:::s-cáʔaqʷ
-n:::c/ts:::*tsánmᴇn:::doak:::cánmən:::ts<u>a</u>nmn:::Chinaman:::note:::cánmən
-n:::c/ts:::s-tsaqụm:::doak:::s-caqəm:::s-tsaqm:::strawberry:::note:::s-caqəm
-n:::c/ts:::tsätxʷ:::doak:::cɛtxʷ:::tsetkhw:::house:::note:::cɛtxʷ
-n:::c/ts:::hɩn-tsäˊx̣ut:::doak:::hən-cáx̣ut:::hn-ts<u>a</u>qhut:::stream river:::note:::hən-cáx̣ut
-n:::c/ts:::s-tsí'<sup>ɩ</sup>läɬ:::doak:::s-cíʔlɛɫ:::s-ts<u>i</u>'leɫ:::substitute:::note:::s-cíʔlɛɫ
-n:::c/ts:::tsicps:::doak:::cišps:::tsishps:::fisher:::note:::cišps
-n:::c/ts:::tsutsyu'<sup>u</sup>:::doak:::cucyuʔ:::tsutsyu':::firetongs:::note:::cucyuʔ
-n:::c/ts:::tsɩtsíy̕ä'<sup>ä</sup>:::doak:::cəcíy'ɛʔ:::tsts<u>i</u>'ye':::w.s. younger speaker:::note:::cəcíy'ɛʔ
-n:::c/ts:::s-tsumt:::doak:::s-cumt:::s-tsumt:::going or coming soon:::note:::s-cumt
-n:::c/ts:::tsuɬum:::doak:::cuɫum:::tsuɫum:::buffalo:::note:::cuɫum
-n:::c/ts:::ä-tsᴐm̕ɬxʷ:::doak:::ɛ-cɔm'ɫxʷ:::e-tso'mɫkhw:::long house:::note:::ɛ-cɔm'ɫxʷ
-n:::c/ts:::a-tsᴇtsᴐqálipä:::doak:::ɛ-cɔm'ɫxʷ:::a-cəcɔqálipɛ:::red nits:::note:::ɛ-cɔm'ɫxʷ
-n:::c/ts:::ä-tsụxʷ-tsụxʷ-wᴇy̕ípä'<sup>ä</sup>:::doak:::ɛ-cəxʷ-cəxʷ-wəyípɛʔ:::e-tskhw-tskhw-wy<u>i</u>pe':::rosehips:::note:::ɛ-cəxʷ-cəxʷ-wəyípɛʔ 
-n:::c/ts:::s-ts̕am̕:::doak:::s-cam':::s-tsa'm:::bone, be bony:::note:::s-cam'
-n:::c'/ts':::ts̕án̕ts̕ᴇn̕:::doak:::c'án'c'ən':::ts'<u>a</u>'nts''n:::grasshopper:::note:::c'án'c'ən'
-n:::c'/ts':::ts̕áq̕-äɬp:::doak:::c'áq'-ɛɫp:::ts'<u>a</u>q'-eɫp:::fir:::note:::c'áq'-ɛɫp
-n:::c'/ts':::ts̕ax̣yú'<sup>u</sup>ts̕ᴇn:::doak:::c'ax̣yúʔc'ən:::ts'aqhy<u>u</u>'ts'n:::mink:::note:::c'ax̣yúʔc'ən
-n:::c'/ts':::ts̕álus:::doak:::c'álus:::ts'<u>a</u>lus:::kingfisher:::note:::c'álus
-n:::c'/ts':::a-ts̕áṛʷläp:::doak:::a-c'áʕʷlɛp:::a-ts'<u>a</u>(wlep:::punk:::note:::a-c'áʕʷlɛp
-n:::c'/ts':::s-ts̕ä<sup>ä</sup>w̕-íɬcᴇn̕:::doak:::s-c'ɛw'-íɫšən':::s-ts'e'w-<u>i</u>ɫsh'n:::splinter-leg:::note:::s-c'ɛw'-íɫšən'
-n:::c'/ts':::ts̕äkukʷ:::doak:::c'ɛkukʷ:::ts'ekukw:::elderberry:::note:::c'ɛkukʷ
-n:::c'/ts':::hɩn-ts̕älcalps:::doak:::hən-c'ɛlšalps:::hn-ts'elshalps:::hardtack (a "story" word):::note:::hən-c'ɛlšalps
-n:::c'/ts':::ts̕i'<sup>ɩ</sup>:::doak:::c'iʔ:::ts'i':::deer:::note:::c'iʔ
-n:::c'/ts':::s-ts̕ict:::doak:::s-c'išt:::s-ts'isht:::m.s wife's brother, sister's husband:::note:::s-c'išt 
-n:::c'/ts':::ts̕íxʷts̕ụxʷ:::doak:::c'íxʷc'əxʷ:::ts'<u>i</u>khwts'khw:::fishhawk:::note:::c'íxʷc'əxʷ
-n:::c'/ts':::s-ts̕ú'<sup>u</sup>-cᴇn̕:::doak:::s-c'úʔ-šən:::s-ts'<u>u</u>'-shn:::foot (of slaughtered animal):::note:::s-c'úʔ-šən
-n:::c'/ts':::s-ts̕ᴐm̕̕-ts̕ᴐm̕̕-ɬt:::doak:::s-c'óm'-c'ɔm'-ɫt:::s-ts'<u>o</u>'m-ts'o'm-ɫt:::boil:::note:::s-c'óm'-c'ɔm'-ɫt
-n:::c'/ts':::s-c-ts̕ᴇs-lúsä'<sup>ä</sup>:::doak:::s-š-c'əs-lúsɛʔ:::s-sh-ts's-l<u>u</u>se':::hail:::note:::s-š-c'əs-lúsɛʔ
-n:::š/sh:::cämän̕:::doak:::šɛmɛn':::sheme'n:::enemy:::note:::šɛmɛn'
-n:::š/sh:::s-cät̕ᴇt:::doak:::s-šɛt'ət:::s-shet't :::cubs:::note:::s-šɛt'ət
-n:::š/sh:::cät̕ut:::doak:::šɛt'ut:::shet'ut:::rock:::note:::šɛt'ut
-n:::š/sh:::s-cäˊmpᴇm:::doak:::s-šɛ́mpəm:::s-sh<u>e</u>mpm:::dense fog:::note:::s-šɛ́mpəm
-n:::š/sh:::n-cäˊgwäl:::doak:::n-šɛ'gʷɛl:::n-she'gwel:::road:::note:::n-šɛ'gʷɛl
-n:::š/sh:::uhɩs-ci'<sup>ɩ</sup>míc:::doak:::sailuhəs-šiʔmíš:::uhs-shi'm<u>i</u>sh:::my favorite:::note:::uhəs-šiʔmíš
-n:::š/sh:::ciw̕t:::doak:::šiw't:::shi'wt:::rat:::note:::šiw't
-n:::š/sh:::cɩciw̕t:::doak:::šəšiw't:::shshi'wt:::be daughter, girl:::note:::šəšiw't
-n:::ǰ/j:::*djísu:::doak:::ǰísu:::j<u>i</u>su:::Jesus:::note:::ǰísu
-n:::ǰ/j:::*djisᴐ<sup>ᴐ</sup>kri:::doak:::ǰisɔkri:::nico:::Jesus Christ:::note:::ǰisɔkri
-n:::ǰ/j:::*djᴐn:::doak:::ǰɔn:::jon:::John:::note:::ǰɔn
-n:::č/ch:::*tcätulí:::doak:::čɛtulí:::chetul<u>i</u>:::Catholic:::note:::čɛtulí
-n:::č/ch:::tcäˊläxʷ:::doak:::čɛ́lɛxʷ:::ch<u>e</u>lekhw:::muskrat:::note:::čɛ́lɛxʷ
-n:::č/ch:::s-t-tcäˊlxụm:::doak:::s-t-čɛ́lxəm:::s-t-ch<u>e</u>lkhm:::yellowhammer:::note:::s-t-čɛ́lxəm
-n:::č/ch:::s-tcint:::doak:::s-čint:::s-chint:::person:::note:::s-čint
-n:::č/ch:::s-t-tc-tcin̕tus:::doak:::s-t-č-čin'tus:::s-t-ch-chi'ntus:::pupil of eye:::note:::s-t-č-čin'tus
-n:::č/ch:::s-tcítsu'ụmc:::doak:::s-čícuʔəmš:::s-ch<u>i</u>tsu'msh:::Coeur d'Alene:::note:::s-čícuʔəmš
-n:::č/ch:::s-tcil:::doak:::s-čil:::s-chil:::game being tracked, quarry:::note:::s-čil
-n:::č/ch:::t-tcɩn-ítkupᴇn:::doak:::t-čən-ítkupən:::t-chn-<u>i</u>tkupn:::Englishman (King Georgeman):::note:::t-čən-ítkupən
-n:::č/ch:::*s-tcɩntsᴐˊts:::doak:::sail:::nico:::english:::note:::
-n:::č/ch:::tcɩtcäy̕ä'<sup>ä</sup>:::doak:::čəčɛy'ɛʔ:::chche'ye:::w.s. mother's mother, daughter's child:::note:::čəčɛy'ɛʔ
-n:::č/ch:::tcsups:::doak:::čsups:::chsups:::tail:::note:::čsups
-n:::č'/ch':::s-tc̕a'<sup>a</sup>-qín̕-cᴇn:::doak:::s-č'aɛʔ-qín'-šən':::s-ch'ae'-q<u>i</u>'n-sh'n:::knee, knuckle:::note:::s-č'aɛʔ-qín'-šən'
-n:::č'/ch':::s-tc̕ä'ílup:::doak:::s-č'ɛʔílup:::s-ch'e'<u>i</u>lup:::last living relative:::note:::s-č'ɛʔílup
-n:::č'/ch':::tc̕äsᴇn̕:::doak:::č'ɛsən':::ch'es'n:::louse:::note:::č'ɛsən'
-n:::č'/ch':::s-tc̕äxuxʷ:::doak:::s-č'ɛxuxʷ:::s-ch'ekhukhw:::tuberculosis:::note:::s-č'ɛxuxʷ
-n:::č'/ch':::tc̕äx̣-qᴇn̕:::doak:::č'ɛx-qən:::ch'ekh-qn:::helldiver:::note:::č'ɛx-qən
-n:::č'/ch':::tc̕i'<sup>ɩ</sup>:::doak:::č'iʔ:::ch'i':::antler, horn:::note:::č'iʔ
-n:::č'/ch':::ä<sup>ä</sup>-tc̕ímul:::doak:::ɛ-č'ímul:::e-ch'<u>i</u>mul:::pine needles:::note:::ɛ-č'ímul
-n:::č'/ch':::s-tc̕im̕:::doak:::s-č'im':::s-ch'i'm:::unidentified animal:::note:::s-č'im'
-n:::č'/ch':::s-t-tc̕íh-ayus:::doak:::s-t-č'íh-ayus:::s-t-ch'<u>i</u>h-ayus:::dandelion:::note:::s-t-č'íh-ayus
-n:::č'/ch':::*tc̕ulai:::doak:::č'ulai:::ch'ulai:::July 4:::note:::č'ulai
-n:::y, y':::yax̣-yax̣-út.cᴇn̕:::doak:::yax̣-yax̣-útšən:::yaqh-yaqh-<u>u</u>tshn:::badger:::note:::yax̣-yax̣-útšən
-n:::y, y':::yuxʷmús:::doak:::yuxʷmús:::yukhwm<u>u</u>s:::Cold:::note:::yuxʷmús
-n:::y, y':::yᴐˊp-yᴐp-änä'<sup>ä</sup>:::doak:::yóp-yɔp-ɛnɛʔ:::y<u>o</u>p-yop-ene':::man-eaters:::note:::yóp-yɔp-ɛnɛʔ
-n:::y, y':::yɩlmíxụm:::doak:::yəlmíxəm:::ylm<u>i</u>khm:::chief:::note:::yəlmíxəm
-n:::y, y':::hɩn-y̕ar̕íp:::doak:::hən-y'ar'íp:::hn-'ya'r<u>i</u>p:::rear of house:::note:::hən-y'ar'íp
-n:::y, y':::y̕úkʷä'<sup>ä</sup>:::doak:::y'úkʷɛʔ:::'y<u>u</u>kwe':::w.s. younger brother:::note:::y'úkʷɛʔ
-n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-gwárpᴇm:::doak:::s-gʷárpɛm:::s-gw<u>a</u>rpem:::flower:::note:::s-gʷárpɛm
-n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-kum-kum-íwut.cᴇn:::doak:::s-kum-kum-íwutšən:::s-kum-kum-<u>i</u>wutsh:::rainbow:::note:::s-kum-kum-íwutšən
-n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-kʷäs-kʷäs:::doak:::s-kʷɛs-kʷɛs:::s-kwes-kwes:::chicken, pheasant:::note:::s-kʷɛs-kʷɛs
-n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-k̕ús-ɩstcä'<sup>ä</sup>:::doak:::s-k'us-əsčɛʔ:::s-k'us-sche':::ghost:::note:::s-k'us-əsčɛʔ
-n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-t-k̕ʷáys-alqʷ:::doak:::s-t-k'ʷáy's-alqʷ:::s-t-k'w<u>a</u>'ys-alqw:::cedar tree:::note:::s-t-k'ʷáy's-alqʷ
-n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::k̕ʷäpt:::doak:::k'ʷɛpt:::k'wept:::spine, backbone:::note:::k'ʷɛpt
-n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-k̕u-k̕ʷäˊl̕:::doak:::s-k'u-k'ʷɛ́l':::s-k'u-k'w<u>e</u>'l:::porcupine:::note:::s-k'u-k'ʷɛ́l'
-n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-k̕ʷụt̕-k̕ʷít̕-ups:::doak:::s-k'ʷət'-kʷít'-ups:::s-k'wt'-kw<u>i</u>t'-ups:::flea:::note:::s-k'ʷət'-kʷít'-ups
-n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::k̕ʷít̕an  [sic]:::doak:::k'ʷít'ɛn':::k'w<u>i</u>t'e'n:::mouse:::note:::k'ʷít'ɛn'
-n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-k̕u-k̕ʷụt-il̕t:::doak:::s-k'u-k'ʷət-il't:::s-k'u-k'wt-i'lt:::fawn:::note:::s-k'u-k'ʷət-il't
-n:::xʷ/khw:::s-xú'<sup>u</sup>n-ätc:::doak:::s-xúʔn-ɛč:::s-kh<u>u</u>'n-ech:::thornberry:::note:::s-xúʔn-ɛč
-n:::xʷ/khw:::s-xʷáyapaqᴇn:::doak:::s-xʷáyapaqən:::s-khw<u>a</u>yapaqn:::red willow:::note:::s-xʷáyapaqən
-n:::xʷ/khw:::xʷäm-äˊtct:::doak:::xʷɛm-ɛ́čt:::khwem-<u>e</u>cht:::woodpecker:::note:::xʷɛm-ɛ́čt
-n:::xʷ/khw:::xʷälä'<sup>ä</sup>:::doak:::xʷɛlɛʔ:::khwele':::meadowlark:::note:::xʷɛlɛʔ
-n:::xʷ/khw:::xʷäṛʷ:::doak:::xʷɛʕʷ:::khwe(w:::bear intestines:::note:::xʷɛʕʷ
-n:::xʷ/khw:::s-xʷít̕-ätcn̕:::doak:::s-xʷít'-ɛčn':::s-khw<u>i</u>t'-ech'n:::dentalium:::note:::s-xʷít'-ɛčn'
-n:::xʷ/khw:::s-xʷut̕i'<sup>ɩ</sup>:::doak:::s-xʷutiʔ:::s-khwuti':::goat:::note:::s-xʷutiʔ
-n:::xʷ/khw:::xʷụts̕út:::doak:::xʷəc'út:::khwts'<u>u</u>t:::Rocky Mountains:::note:::xʷəc'út
-n:::xʷ/khw:::s-xʷụlíkʷ:::doak:::s-xʷəlíkʷ:::s-khwl<u>i</u>kw:::whirlwind:::note:::s-xʷəlíkʷ
-n:::xʷ/khw:::s-xʷul-ᴐˊtqᴇn:::doak:::s-xʷəl-ótqən:::s-khwl-<u>o</u>tqn:::Jack Rabbit:::note:::s-xʷəl-ótqən
-n:::xʷ/khw:::s-xu-xʷᴐˊm̕-qᴇn̕:::doak:::s-xu-xʷóm'-qən':::s-khu-khw<u>o</u>'m-q'n:::spoon of antler:::note:::s-xu-xʷóm'-qən'
-n:::xʷ/khw:::s-xu-xʷᴐˊl-qᴇn:::doak:::s-xu-xʷól-qən':::s-khu-khw<u>o</u>l-q'n:::spearhead of antler:::note:::s-xu-xʷól-qən'
-n:::q:::sɩn-qä<sup>ä</sup>m-íl̕tups:::doak:::sən-qɛm-íl'tups:::sn-qem-<u>i</u>'ltups:::dung (Coyote's powers):::note:::sən-qɛm-íl'tups
-n:::q:::qäyí'us:::doak:::qɛyíʔus:::qey<u>i</u>'us:::Cayuse:::note:::qɛyíʔus
-n:::q:::qälɩspíläm:::doak:::qɛləspílɛm:::qelsp<u>i</u>lem:::Kalispelm country:::note:::qɛləspílɛm
-n:::q:::qälpyä:::doak:::qɛlpyɛ:::qelpye:::black swan:::note:::qɛlpyɛ
-n:::q:::s-qäl̕sí:::doak:::s-qɛl'sí:::s-qe'ls<u>i</u>:::Kutenai:::note:::s-qɛl'sí
-n:::q:::qinä'<sup>ä</sup>:::doak:::qinɛʔ:::qine':::father's mother:::note:::qinɛʔ
-n:::q:::qitstc:::doak:::qicč:::qitsch:::older brother:::note:::qicč
-n:::q:::s-qigwts:::doak:::s-qiqʷc:::s-qiqwts:::wild potato (?) (grows in water):::note:::s-qiqʷc
-n:::q:::qíxʷɩlc:::doak:::qíxʷəlš:::q<u>i</u>khwlsh:::fish:::note:::qíxʷəlš
-n:::q:::qilttc:::doak:::qiltč:::qiltch:::flesh, meat:::note:::qiltč
-n:::q:::qil̕tụmxʷ:::doak:::qil'təmxʷ:::qi'ltmkhw:::man, husband:::note:::qil'təmxʷ
-n:::q:::ä-qu-qul̕i'<sup>ɩ</sup>t:::doak:::ɛ-qu-qul'iʔt:::e-qu-qu'li't:::balsam fir:::note:::ɛ-qu-qul'iʔt
-n:::q':::s-q̕äp-q̕ä<sup>ä</sup>p-ínä'<sup>ä</sup>:::doak:::s-q'ɛp-q'ɛp-ínɛʔ:::s-q'ep-q'ep-<u>i</u>ne':::sand:::note:::s-q'ɛp-q'ɛp-ínɛʔ
-n:::q':::tcat-q̕äˊl-äy̕:::doak:::čat-q'ɛ́l-ɛy':::chat-q'<u>e</u>l-e'y:::lake (Chatcolet):::note:::čat-q'ɛ́l-ɛy'
-n:::q':::s-q̕äl-íw̕äs-cᴇn:::doak:::s-q'ɛl-íw'ɛs-šən:::s-q'el-<u>i</u>'wes-shn:::snowshoes:::note:::s-q'ɛl-íw'ɛs-šən
-n:::q':::s-q̕äl̕-äps:::doak:::s-q'ɛl'-ɛps:::s-q'e'l-eps:::horse collar, necklace:::note:::s-q'ɛl'-ɛps
-n:::q':::s-q̕äˊh-q̕äh:::doak:::s-q'ɛ́h-q'ɛh:::s-q'<u>e</u>h-q'eh:::small red chickenhawk:::note:::s-q'ɛ́h-q'ɛh
-n:::q':::q̕ip̕xʷä'<sup>ä</sup>:::doak:::q'ip'xʷɛʔ:::q'ip'khwe':::walnut:::note:::q'ip'xʷɛʔ
-n:::q':::q̕u-q̕ụm̕íw̕äs:::doak:::q'u-q'əm'íw'ɛs:::q'u-q''m<u>i</u>'wes:::colt:::note:::q'u-q'əm'íw'ɛs
-n:::q':::q̕uts̕wíyä'<sup>ä</sup>:::doak:::q'uc'wíyɛʔ:::q'uts'w<u>i</u>ye':::chipmunk:::note:::q'uc'wíyɛʔ
-n:::q':::q̕uyä'<sup>ä</sup>:::doak:::q'uyɛʔ:::q'uye':::name of Coyote's powers:::note:::q'uyɛʔ
-n:::q':::q̕ᴐm-qᴇn:::doak:::q'ɔm-qən:::q'om-qn:::(or k'ɔmqən) head:::note:::q'ɔm-qən
-n:::x̣/qh:::x̣ä'úlụmxʷ:::doak:::x̣ɛʔúləmxʷ:::qhe'<u>u</u>lmkhw:::rattlesnake:::note:::x̣ɛʔúləmxʷ
-n:::x̣/qh:::x̣äˊläxʷ:::doak:::x̣ɛ́lɛxʷ:::qh<u>e</u>lekhw:::tooth:::note:::x̣ɛ́lɛxʷ
-n:::x̣/qh:::x̣älíqʷä'<sup>ä</sup>:::doak:::x̣ɛlíqʷɛʔ:::qhel<u>i</u>qwe':::dried salmon roe:::note:::x̣ɛlíqʷɛʔ
-n:::x̣/qh:::x̣ípä'<sup>ä</sup>:::doak:::x̣ípɛʔ:::qh<u>i</u>pe':::father's father, son's child:::note:::x̣ípɛʔ
-n:::x̣/qh:::s-x̣ít̕-ụmcᴇn:::doak:::s-x̣ít'-əmšən:::s-qh<u>i</u>t'-mshn:::leggings, trousers:::note:::s-x̣ít'-əmšən
-n:::x̣/qh:::s-x̣íy-ä'<sup>ä</sup>st:::doak:::s-x̣íy-ɛʔst:::s-qh<u>i</u>y-e'st:::cooking stones:::note:::s-x̣íy-ɛʔst
-n:::qʷ/qw:::s-qʷán-ɬkʷä'äp:::doak:::s-qʷán-ɫkʷɛʔɛp:::s-qw<u>a</u>n-ɫkwe'ep:::empty receptacle:::note:::s-qʷán-ɫkʷɛʔɛp
-n:::qʷ/qw:::s-qʷás-qʷasä'<sup>ä</sup>:::doak:::s-qʷás-qʷasɛʔ:::s-qw<u>a</u>s-qwase':::child:::note:::s-qʷás-qʷasɛʔ
-n:::qʷ/qw:::s-qʷäy-u<sup>u</sup>:::doak:::s-qʷɛy-uʔ:::s-qwey-u':::grape:::note:::s-qʷɛy-uʔ
-n:::qʷ/qw:::s-qʷím̕-us:::doak:::s-qʷím'-us:::s-qw<u>i</u>'m-us:::woodtick:::note:::s-qʷím'-us
-n:::qʷ/qw:::s-qʷíts-ụmc:::doak:::s-qʷíc-əmš:::s-qw<u>i</u>ts-msh:::cottontail:::note:::s-qʷíc-əmš
-n:::qʷ/qw:::qʷíläm̕:::doak:::qʷílɛm':::qw<u>i</u>le'm:::song:::note:::qʷílɛm'
-n:::qʷ/qw:::qʷụlíwɩl̕c:::doak:::qʷəlíwəl'š:::qwl<u>i</u>w'lsh:::onion:::note:::qʷəlíwəl'š
-n:::q'ʷ/q'w:::q̕ʷäsu<sup>u</sup>:::doak:::q'ʷɛsu:::q'wesu:::bunch:::note:::q'ʷɛsu
-n:::q'ʷ/q'w:::s-q̕ʷäq̕ʷ-alqʷ:::doak:::s-q'ʷɛq'ʷ-alqʷ:::s-q'weq'w-alqw:::prairie grouse:::note:::s-q'ʷɛq'ʷ-alqʷ
-n:::q'ʷ/q'w:::sɩn-q̕ʷụdä'úscᴇn:::doak:::sən-q'ʷədɛʔúsšən:::sn-q'wde'<u>u</u>sshn:::root:::note:::sən-q'ʷədɛʔúsšən
-n:::q'ʷ/q'w:::s-t-q̕ʷụsúm̕:::doak:::s-t-q'ʷəsúm':::s-t-q'ws<u>u</u>'m:::weasel:::note:::s-t-q'ʷəsúm'
-n:::q'ʷ/q'w:::q̕ʷuts̕wiyä'<sup>ä</sup>:::doak:::q'ʷuc'wiyɛʔ:::q'wuts'wiye':::chipmunk:::note:::q'ʷuc'wiyɛʔ
-n:::x̣ʷ/qhw:::s-x̣u'<sup>u</sup>xʷ:::doak:::s-x̣uʔxʷ:::s-qhu'khw:::steam, vapor:::note:::s-x̣uʔxʷ
-n:::x̣ʷ/qhw:::s-x̣úsᴇm:::doak:::s-x̣úsəm:::s-qh<u>u</u>sm:::soapberry:::note:::s-x̣úsəm
-n:::x̣ʷ/qhw:::x̣ʷát-x̣ʷat:::doak:::x̣ʷát-x̣ʷat:::qhw<u>a</u>t-qhwat:::duck:::note:::x̣ʷát-x̣ʷat
-n:::x̣ʷ/qhw:::s-x̣ʷụɬ-x̣ʷáɬ:::doak:::x̣ʷəɫ-x̣ʷáɫ:::qhwɫ-qhw<u>a</u>ɫ:::Rocky Mt. sheep:::note:::x̣ʷəɫ-x̣ʷáɫ
-n:::x̣ʷ/qhw:::s-x̣ʷal-ístcᴇn:::doak:::s-x̣ʷal-ísčən:::s-qhwal-<u>i</u>schn:::buck (deer):::note:::s-x̣ʷal-ísčən
-n:::x̣ʷ/qhw:::s-x̣ʷäˊṛʷ-x̣ʷäṛʷ:::doak:::s-x̣ʷɛ́ʕʷ-x̣ʷɛʕʷ:::s-qhw<u>e</u>(w-qhwe(w:::fox:::note:::s-x̣ʷɛ́ʕʷ-x̣ʷɛʕʷ
-n:::l:::*lawan:::doak:::lawan:::lawan:::oats:::note:::lawan
-n:::l:::láx̣ʷ-lụxʷ  [sic]:::doak:::láx̣ʷ-ləxʷ:::l<u>a</u>qhw-lkhw:::cherry:::note:::láx̣ʷ-ləxʷ
-n:::l:::s-lä<sup>ä</sup>w̕ínätc:::doak:::s-lɛw'ínɛč:::s-le'w<u>i</u>nech:::crickets:::note:::s-lɛw'ínɛč
-n:::l:::*läbotäm  [sic]:::doak:::lɛbotɛm:::lebotem:::bottle:::note:::lɛbotɛm
-n:::l:::*lä<sup>ä</sup>swip:::doak:::lɛswip:::leswip:::Jew:::note:::lɛswip
-n:::l:::*lᴇsa<sup>a</sup>pᴐt:::doak:::ləsapɔt:::lsapot:::apostles:::note:::ləsapɔt
-n:::l:::lup̕ay̕:::doak:::lup'ay':::lup'a'y:::basket:::note:::lup'ay'
-n:::l:::lɩtkú:::doak:::lətkú:::ltk<u>u</u>:::otter:::note:::lətkú
-n:::l:::lᴇkapí:::doak:::ləkapí:::lkap<u>i</u>:::coffee:::note:::ləkapí
-n:::l:::lụqᴐsᴐˊ:::doak:::ləqɔsó:::lqos<u>o</u>:::pig:::note:::ləqɔsó
-n:::ɫ, l':::hɩn-ɬámqä'<sup>ä</sup>:::doak:::hən-ɫámqɛʔ:::hn-ɫ<u>a</u>mqe':::black bear:::note:::hən-ɫámqɛʔ
-n:::ɫ, l':::s-tc-ɬämt:::doak:::s-č-ɫɛmt:::s-ch-ɫemt:::light fog, dew:::note:::s-č-ɫɛmt
-n:::ɫ, l':::s-tc-ɬus-mᴇn:::doak:::s-č-ɫus-mən:::s-ch-ɫus-mn:::eye:::note:::s-č-ɫus-mən
-n:::ɫ, l':::s-ɬụxʷ-tct:::doak:::s-ɫəxʷ-čt:::s-ɫkhw-cht:::glove:::note:::s-ɫəxʷ-čt
-n:::ɫ, l':::ɬɩtcíp:::doak:::ɫəčíp:::ɫch<u>i</u>p:::bucket:::note:::ɫəčíp
-n:::ɫ, l':::l̕ᴇl̕ᴇpᴐˊt:::doak:::l'əl'əpót:::'l'lp<u>o</u>t:::cup:::note:::l'əl'əpót
-n:::ɫ, l':::l̕äl̕ɩq̕ʷɩl̕c:::doak:::l'ɛl'əq'ʷəl'š:::'le'lq'w'lsh:::ripples:::note:::l'ɛl'əq'ʷəl'š
-n:::ʕ, ʕʷ/(, (w:::s-ʀin:::doak:::s-ʕin:::s-(in:::catbird:::note:::s-ʕin
-n:::ʕ, ʕʷ/(, (w:::s-ʀíhänt:::doak:::s-ʕíhɛnt:::s-(<u>i</u>hent:::goose:::note:::s-ʕíhɛnt
-n:::ʕ, ʕʷ/(, (w:::s-ṛʷäˊl-gụl:::doak:::s-ʕʷɛ́l-gəl:::s-(w<u>e</u>l-gl:::fishnet, bagnet:::note:::s-ʕʷɛ́l-gəl
-n:::h:::háy-aqs:::doak:::háy-aqs:::h<u>a</u>y-aqs:::pearl:::note:::háy-aqs
-n:::h:::hamäˊɬtᴇmc:::doak:::hamɛɫtəmš:::hameɫtmsh:::fly, insect, maggot:::note:::hamɛɫtəmš
-n:::h:::hɩn-hala<sup>a</sup>tsäˊ:::doak:::hən-halacɛ́:::hn-halats<u>e</u>:::(or cín) raspberry:::note:::hən-halacɛ́
-n:::h:::hämä'<sup>ä</sup>:::doak:::hɛmɛʔ:::heme':::French:::note:::hɛmɛʔ
+v:::x̣/qh:::x̣ämts:::doak:::x̣ɛmc:::qhemts:::shave hair::: :::x̣ɛmc
+v:::x̣/qh:::x̣ät:::doak:::x̣ɛt:::qhet:::punish::: :::x̣ɛt
+v:::x̣/qh:::x̣ät:::doak:::x̣ɛt:::qhet:::club::: :::x̣ɛt
+v:::x̣/qh:::x̣ät̕:::doak:::x̣ɛt':::qhet':::gnaw, eat close, graze::: :::x̣ɛt'
+v:::x̣/qh:::x̣äs:::doak:::x̣ɛs:::qhes:::be well, be good::: :::x̣ɛs
+v:::x̣/qh:::x̣äts:::doak:::x̣ɛc:::qhets:::be ready, clothed, get ready::: :::x̣ɛc
+v:::x̣/qh:::x̣ätsut:::doak:::x̣ɛcut:::qhetsut:::be companion to::: :::x̣ɛcut
+v:::x̣/qh:::x̣äts̕:::doak:::x̣ɛc'(u-):::qhets'(u-):::arouse curiosity::: :::x̣ɛc'(u-)
+v:::x̣/qh:::x̣äy:::doak:::x̣ɛy:::qhey:::be left over::: :::x̣ɛy
+v:::x̣/qh:::x̣äl:::doak:::x̣ɛl:::qhel:::lay evenly (as lumber)::: :::x̣ɛl
+v:::x̣/qh:::x̣äl:::doak:::x̣ɛl:::qhel:::be clear, bright, light::: :::x̣ɛl
+v:::x̣/qh:::x̣äʀigw:::doak:::x̣ɛʕigʷ(-t):::qhe(igw(-t):::be full of holes so air can pass through::: :::x̣ɛʕigʷ(-t)
+v:::x̣/qh:::x̣ip:::doak:::x̣ip:::qhip:::gnaw to destroy (as beaver, mouse, squirrel)::: :::x̣ip
+v:::x̣/qh:::x̣iw:::doak:::x̣iw:::qhiw:::be shy, timid, ashamed, embarrassed::: :::x̣iw
+v:::x̣/qh:::x̣iw̕:::doak:::x̣iw':::qhi'w:::be raw (uncooked)::: :::x̣iw'
+v:::x̣/qh:::x̣it:::doak:::x̣it:::qhit:::be corrugated marked::: :::x̣it
+v:::x̣/qh:::x̣its:::doak:::x̣ic:::qhits:::threaten with hand::: :::x̣ic
+v:::x̣/qh:::x̣iy:::doak:::x̣iy:::qhiy:::gray (as horse)::: :::x̣iy
+v:::x̣/qh:::x̣il:::doak:::x̣il:::qhil:::lick from (as salt from ground)::: :::x̣il
+v:::x̣/qh:::x̣iɬ:::doak:::x̣iɫ:::qhiɫ:::fear::: :::x̣iɫ
+v:::x̣/qh:::x̣iɬ:::doak:::x̣iɫ:::qhiɫ:::leave, desert::: :::x̣iɫ
+v:::x̣/qh:::x̣us:::doak:::x̣us:::qhus:::foam (like beer)::: :::x̣us
+v:::x̣/qh:::x̣ᴐlq̕ʷ:::doak:::x̣ɔlq'ʷ:::qholq'w:::wind string evenly::: :::x̣ɔlq'ʷ
+v:::qʷ/qw:::qʷa'<sup>a</sup>qʷä'<sup>ä</sup>l:::doak:::qʷaʔqʷɛʔl:::qwa'qwe'l:::speak, talk::: :::qʷaʔqʷɛʔl
+v:::qʷ/qw:::qʷam:::doak:::qʷam:::qwam:::be pleasant, comfortable, fascinating, pleasing::: :::qʷam
+v:::qʷ/qw:::qʷay:::doak:::qʷay:::qway:::joke, talk backward::: :::qʷay
+v:::qʷ/qw:::qʷä'<sup>ä</sup>:::doak:::qʷɛʔ:::qwe':::continue with::: :::qʷɛʔ
+v:::qʷ/qw:::qʷäm̕:::doak:::qʷɛm':::qwe'm:::ignore, be oblivious to::: :::qʷɛm'
+v:::qʷ/qw:::qʷäs:::doak:::qʷɛs(u-):::qwes(u-):::blur, be foolish::: :::qʷɛs(u-)
+v:::qʷ/qw:::qʷäy̕:::doak:::qʷɛy':::qwe'y:::be poor, pitiable, pity::: :::qʷɛy'
+v:::qʷ/qw:::qʷäl̕:::doak:::qʷɛl':::qʷɛl':::be livid, bluish, angry::: :::qʷɛl'
+v:::qʷ/qw:::qʷäṛʷ:::doak:::qʷɛʕʷ(u-):::qwe(w(u-):::be insane, drunk, foolish, irresponsible::: :::qʷɛʕʷ(u-)
+v:::qʷ/qw:::qʷäl̕:::doak:::qʷɛl':::qwe'l:::enkindle, light::: :::qʷɛl'
+v:::qʷ/qw:::qʷi'<sup>ɩ</sup>:::doak:::qʷiʔ:::qwi':::be hollow::: :::qʷiʔ
+v:::qʷ/qw:::qʷi'<sup>ɩ</sup>:::doak:::qʷiʔ:::qwi':::be accustomed to::: :::qʷiʔ
+v:::qʷ/qw:::qʷin:::doak:::qʷin:::qwin:::be blue::: :::qʷin
+v:::qʷ/qw:::qʷits:::doak:::qʷic:::qwits:::be warm::: :::qʷic
+v:::qʷ/qw:::qʷiy:::doak:::qʷiy(u-):::qwiy(u-):::have plenty::: :::qʷiy(u-)
+v:::qʷ/qw:::qʷiy̕:::doak:::qʷiy'(-t):::qwi'y(-t):::have pity for::: :::qʷiy'(-t)
+v:::qʷ/qw:::qʷil:::doak:::qʷil:::qwil:::cheat::: :::qʷil
+v:::qʷ/qw:::qʷil̕:::doak:::qʷil':::qwi'l:::kindle, light, make fire::: :::qʷil'
+v:::qʷ/qw:::qʷil̕:::doak:::qʷil':::qwi'l:::starve::: :::qʷil'
+v:::qʷ/qw:::qʷuˑn:::doak:::qʷun(u-):::qwun(u-):::be blue, green::: :::qʷun(u-)
+v:::q'ʷ/q'w:::reichard:::doak:::q'us:::q'us:::be gathered, wrinkled::: :::q'us
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷal(-t):::q'wal(-t):::be black from burning::: :::q'ʷal(-t)
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛd:::q'wed:::be black::: :::q'ʷɛd
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛn'p':::q'we'np':::go out of sight, disappear::: :::q'ʷɛn'p'
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛs:::q'wes:::be wrinkled, shriveled::: :::q'ʷɛs
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛc:::q'wets:::pl. are enduring, solid, firm::: :::q'ʷɛc
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛy':::q'we'y:::bounce, dance::: :::q'ʷɛy'
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛy':::q'we'y:::wring, choke::: :::q'ʷɛy'
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛl:::q'wel:::cook, burn::: :::q'ʷɛl
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷɛɫ:::q'weɫ:::have endurance, be long-winded::: :::q'ʷɛɫ
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷid:::q'wid:::make black, blacken::: :::q'ʷid
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷiʔɫ:::q'wi'ɫ:::move camp, village travels::: :::q'ʷiʔɫ
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷic'(-t):::q'wits'(-t):::be full::: :::q'ʷic'(-t)
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷiɫ:::q'wiɫ:::be enduring, persevering (in general sense)::: :::q'ʷiɫ
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷih:::q'wih:::be black (in describing person)::: :::q'ʷih
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷəd(u-):::q'wd(u-):::be black (of horses)::: :::q'ʷəd(u-)
+v:::q'ʷ/q'w:::reichard:::doak:::q'ʷəliw:::q'wliw:::bear picks berries::: :::q'ʷəliw
+v:::x̣ʷ/qhw:::x̣up:::doak:::x̣up:::qhup:::be inefficient, careless::: :::x̣up
+v:::x̣ʷ/qhw:::x̣ʷad:::doak:::x̣ʷad:::qhwad:::be comical, be amused, laugh::: :::x̣ʷad
+v:::x̣ʷ/qhw:::x̣ʷat:::doak:::x̣ʷat:::qhwat:::cut in two::: :::x̣ʷat
+v:::x̣ʷ/qhw:::x̣ʷaq̕ʷ:::doak:::x̣ʷaq'ʷ:::qhwaq'w:::divide, separate::: :::x̣ʷaq'ʷ
+v:::x̣ʷ/qhw:::x̣ʷaɬ:::doak:::x̣ʷaɫ:::qhwaɫ:::dart::: :::x̣ʷaɫ
+v:::x̣ʷ/qhw:::x̣ʷän:::doak:::x̣ʷɛn(u-):::qhwen(u-):::hurry to get at::: :::x̣ʷɛn(u-)
+v:::x̣ʷ/qhw:::x̣ʷäts:::doak:::x̣ʷɛc:::qhwets:::pass by::: :::x̣ʷɛc
+v:::x̣ʷ/qhw:::x̣ʷäq̕ʷ:::doak:::x̣ʷɛq'ʷ:::qhweq'w:::grind meal::: :::x̣ʷɛq'ʷ
+v:::x̣ʷ/qhw:::x̣ʷits:::doak:::x̣ʷic:::qhwits:::crop hair::: :::x̣ʷic
+v:::x̣ʷ/qhw:::x̣ʷiɬ:::doak:::x̣ʷiɫ:::qhwiɫ:::hurry at something::: :::x̣ʷiɫ
+v:::l:::la'ax̣ʷ:::doak:::laʔax̣̣ʷ:::la'aqhw:::be daytime, morning, tomorrow::: :::laʔax̣̣ʷ
+v:::l:::laq:::doak:::laq:::laq:::pull out plants::: :::laq
+v:::l:::laq̕:::doak:::laq':::laq':::pare, peel::: :::laq'
+v:::l:::laqʷ:::doak:::laqʷ:::laqw:::store hanging (as tallow in paunch)::: :::laqʷ
+v:::l:::laq̕ʷ:::doak:::laq'ʷ:::laq'w:::be able::: :::laq'ʷ
+v:::l:::lax̣ʷ:::doak:::lax̣ʷ:::laqhw:::pl. round objects lie::: :::lax̣ʷ
+v:::l:::läp̕x̣ʷ:::doak:::lɛp'x̣ʷ:::lep'qhw:::fit into (as ball and socket)::: :::lɛp'x̣ʷ
+v:::l:::lädj:::doak:::lɛǰ(-p):::lej(-p):::stab::: :::lɛǰ(-p)
+v:::l:::reichard:::doak:::lɛǰ:::lej:::sting::: ::: lɛǰ 
+v:::l:::lätc̕:::doak:::lɛč':::lech':::bind::: :::lɛč'
+v:::l:::lätc̕:::doak:::lɛč':::lech':::pl. are fierce::: :::lɛč'
+v:::l:::läkʷ:::doak:::lɛkʷ:::lekw:::be far::: :::lɛkʷ
+v:::l:::läxʷ:::doak:::lɛxʷ(-p):::lekhw(-p):::hurt::: :::lɛxʷ(-p)
+v:::l:::läxʷ:::doak:::lɛxʷ:::lekhw:::perforate, be hole::: :::lɛxʷ
+v:::l:::laq̕:::doak:::laq':::laq':::search for::: :::laq'
+v:::l:::lax̣:::doak:::lax̣:::laqh:::lighten, be electric::: :::lax̣
+v:::l:::lax̣:::doak:::lax̣(-t):::laqh(-t):::be friend::: :::lax̣(-t)
+v:::l:::läq̕:::doak:::lɛq':::leq':::bury::: :::lɛq'
+v:::l:::läṛʷ:::doak:::lɛʕʷ:::le(w :::draw on, make fit::: :::lɛʕʷ
+v:::l:::lic:::doak:::liš:::lish:::be hilly, mountain::: :::liš
+v:::l:::li'<sup>ɩ</sup>lä'<sup>ä</sup>:::doak:::liʔlɛʔ(-t):::li'le'(-t):::pl. fly::: :::liʔlɛʔ(-t)
+v:::l:::limt:::doak:::lim(-t):::lim(-t):::be glad, thankful, pleased::: :::lim(-t)
+v:::l:::ligw:::doak:::ligʷ(-t):::ligw(-t):::snare, catch in trap::: :::ligʷ(-t)
+v:::l:::lup:::doak:::lup:::lup:::be dry, thirsty::: :::lup
+v:::l:::lut:::doak:::lut:::lut:::be mischievous, not, negative::: :::lut
+v:::l:::luk̕ʷ:::doak:::luk'ʷ:::nluk'w:::pull, pick off strings, fuzz::: :::luk'ʷ
+v:::ɫ:::ɬats:::doak:::ɫac:::ɫats:::one drop falls::: :::ɫac
+v:::ɫ:::ɬapx̣:::doak:::ɫapx̣:::ɫapqh:::be slightly skinned::: :::ɫapx̣
+v:::ɫ:::ɬay:::doak:::ɫay:::ɫay:::make dirty marks, scribble::: :::ɫay
+v:::ɫ:::ɬaxʷ:::doak:::ɫaxʷ:::ɫakhw:::wear, draw on::: :::ɫaxʷ
+v:::ɫ:::ɬaq:::doak:::ɫaq:::ɫaq:::be serviceberry, do with serviceberry::: :::ɫaq
+v:::ɫ:::ɬaq:::doak:::ɫaq:::ɫaq:::mend, patch::: :::ɫaq
+v:::ɫ:::ɬaqi'<sup>ɩ</sup>:::doak:::ɫaqiʔ:::ɫaqi':::pl. lower, fall, dismount::: :::ɫaqiʔ
+v:::ɫ:::ɬaq̕:::doak:::ɫaq':::ɫaq':::be wide::: :::ɫaq'
+v:::ɫ:::ɬaq̕:::doak:::ɫaq':::ɫaq':::person lies on stomach, crouch::: :::ɫaq'
+v:::ɫ:::ɬaqʷ:::doak:::ɫaqʷ:::ɫaqw:::band used with pressure, belt::: :::ɫaqʷ
+v:::ɫ:::ɬaqʷ:::doak:::ɫaqʷ:::ɫaqw:::store hanging, hang on line::: :::ɫaqʷ
+v:::ɫ:::ɬaq̕ʷ:::doak:::ɫaq'ʷ:::ɫaq'w:::skin, pull off::: :::ɫaq'ʷ
+v:::ɫ:::ɬax̣ʷ:::doak:::ɫax̣ʷ:::ɫaqhw:::move with weight and speed::: :::ɫax̣ʷ
+v:::ɫ:::ɬax̣ʷp:::doak:::ɫax̣ʷp:::ɫaqhwp:::escape::: :::ɫax̣ʷp
+v:::ɫ:::ɬax̣ʷp̕:::doak:::ɫax̣ʷp':::ɫaqhwp':::rush::: :::ɫax̣ʷp'
+v:::ɫ:::ɬax̣ʷq̕:::doak:::ɫax̣ʷq':::ɫaqhwq':::foot slips::: :::ɫax̣ʷq'
+v:::ɫ:::ɬaṛʷ:::doak:::ɫaʕʷ(u-):::ɫa(w(u-):::be slippery (as ice)::: :::ɫaʕʷ(u-)
+v:::ɫ:::ɬä'än:::doak:::ɫɛʔɛn :::ɫe'en:::be on opposite side::: :::ɫɛʔɛn 
+v:::ɫ:::ɬäp:::doak:::ɫɛp:::ɫep:::be difficult but possible of achievement, be disgusting::: :::ɫɛp
+v:::ɫ:::ɬäp̕:::doak:::ɫɛp'(u-):::ɫep'(u-):::be undaunted::: :::ɫɛp'(u-)
+v:::ɫ:::reichard:::doak:::ɫɛp':::ɫep':::stripe, mark, make welt::: :::ɫɛp'
+v:::ɫ:::ɬäm̕:::doak:::ɫɛm':::ɫe'm:::apologize::: :::ɫɛm'
+v:::ɫ:::ɬätq̕:::doak:::ɫɛtq':::ɫetq':::splash, drops hit surface::: :::ɫɛtq'
+v:::ɫ:::ɬät̕:::doak:::ɫɛt':::ɫet':::one jumps::: :::ɫɛt'
+v:::ɫ:::ɬäts:::doak:::ɫɛc:::ɫets:::flat objects lie::: :::ɫɛc
+v:::ɫ:::ɬätc̕:::doak:::ɫɛč':::ɫech':::string breaks::: :::ɫɛč'
+v:::ɫ:::ɬäk̕ʷ:::doak:::ɫɛk'ʷ:::ɫek'w:::pierce with fine-pointed object, fork, barb, spike::: :::ɫɛk'ʷ
+v:::ɫ:::ɬäxʷ:::doak:::ɫɛxʷ:::ɫekhw:::draw together, slip on::: :::ɫɛxʷ
+v:::ɫ:::ɬäxʷ:::doak:::ɫɛxʷ:::ɫekhw:::sew::: :::ɫɛxʷ
+v:::ɫ:::ɬäq̕:::doak:::ɫɛq':::ɫeq':::make impound, round up animals::: :::ɫɛq'
+v:::ɫ:::ɬäl:::doak:::ɫɛl:::ɫel:::sprinkle::: :::ɫɛl
+v:::ɫ:::ɬäṛʷ:::doak:::ɫɛʕ:::ɫe(:::skate, slide on ice::: :::ɫɛʕ
+v:::ɫ:::ɬi'<sup>ɩ</sup>:::doak:::ɫiʔ:::ɫi':::be close to edge, be border::: :::ɫiʔ
+v:::ɫ:::ɬip̕:::doak:::ɫip':::ɫip':::make striped (?)::: :::ɫip'
+v:::ɫ:::ɬit̕:::doak:::ɫit':::ɫit':::sprinkle ceremonially::: :::ɫit'
+v:::ɫ:::ɬit̕:::doak:::ɫit':::ɫit':::pl. jump off of, out of::: :::ɫit'
+v:::ɫ:::ɬitk̕ʷ:::doak:::ɫitk'ʷ:::ɫitk'w:::pl. objects jerk into different position::: :::ɫitk'ʷ
+v:::ɫ:::ɬis:::doak:::ɫis:::ɫis:::measure, weigh::: :::ɫis
+v:::ɫ:::ɬɩɬiy̕:::doak:::ɫəɫiy':::ɫɫi'y :::spotted::: :::ɫəɫiy'
+v:::ɫ:::ɬɩɬikʷ:::doak:::ɫəɫikʷ(u-):::ɫɫikw(u-) :::be speckled, small-spotted::: :::ɫəɫikʷ(u-)
+v:::ɫ:::ɬik̕ʷ:::doak:::ɫik'ʷ:::ɫik'w:::hairlike object breaks::: :::ɫik'ʷ
+v:::ɫ:::ɬil:::doak:::ɫil:::ɫil:::sprinkle::: :::ɫil
+v:::ɫ:::ɬu'<sup>u</sup>:::doak:::ɫuʔ:::ɫu':::be there near third person::: :::ɫuʔ
+v:::ɫ:::ɬu'un:::doak:::ɫuʔum:::ɫu'um:::be in opposite direction::: :::ɫuʔum 
+v:::ɫ:::ɬuts̕:::doak:::ɫuc':::ɫuts':::pl. sticklike objects break::: :::ɫuc'
+v:::ɫ:::ɬukʷ:::doak:::ɫukʷ(u-):::ɫukw(u-):::be stained with blood::: :::ɫukʷ(u-)
+v:::ɫ:::ɬuk̕ʷ:::doak:::ɫuk'ʷ:::ɫuk'w:::recall, remember::: :::ɫuk'ʷ
+v:::ɫ:::reichard:::doak:::ɫɔmɛn':::ɫome'n:::scold::: :::ɫɔmɛn'
+v:::ɫ:::ɬᴐmän̕:::doak:::sail:::nico:::english::: :::
+v:::ɫ:::ɬᴐq:::doak:::sail:::nico:::english::: :::
+v:::ɫ:::reichard:::doak:::ɫɔq':::ɫoq':::be bald, bare::: :::ɫɔq'
+v:::l' (derivative):::l̕ɩl̕itc:::doak:::l'əl'ič:::'l'lich:::be thin slice::: :::l'əl'ič
+v:::l' (derivative):::l̕ᴇl̕ax̣:::doak:::l'əl'ax̣:::'l'laqh:::lighten::: :::l'əl'ax̣
+v:::ʕ/(:::ʀaw:::doak:::ʕaw:::(aw:::drop::: :::ʕaw
+v:::ʕ/(:::ʀax̣:::doak:::ʕax̣:::(aqh:::wrap string evenly::: :::ʕax̣
+v:::ʕ/(:::ʀäm:::doak:::ʕɛm(-t):::(em(-t):::melt, dissolve, waste away::: :::ʕɛm(-t)
+v:::ʕ/(:::ʀäts:::doak:::ʕɛc:::(ets:::tie::: :::ʕɛc
+v:::ʕ/(:::ʀäts̕:::doak:::ʕɛc':::(ets':::play out, wear out, become exhausted::: :::ʕɛc'
+v:::ʕ/(:::ʀäts̕xʷ:::doak:::ʕɛc'xʷ:::(ets'khw :::be worn out, tired::: :::ʕɛc'xʷ
+v:::ʕ/(:::ʀäts̕xʷ:::doak:::ʕɛc'xʷ:::(ets'khw :::be hungry for meat, surfeited with vegetable food::: :::ʕɛc'xʷ
+v:::ʕ/(:::ʀäy:::doak:::ʕɛy:::(ey:::be embittered::: :::ʕɛy
+v:::ʕ/(:::ʀäy̕:::doak:::ʕɛy':::(e'y:::be angry::: :::ʕɛy'
+v:::ʕ/(:::ʀäl̕:::doak:::ʕɛl':::(e'l:::obstruct, cover::: :::ʕɛl'
+v:::ʕ/(:::ʀipɩlc:::doak:::ʕipəlš:::(iplsh:::person hides::: :::ʕipəlš
+v:::ʕ/(:::ʀid:::doak:::ʕid:::(id:::glow, become redhot::: :::ʕid
+v:::ʕ/(:::ʀits̕:::doak:::ʕic':::(its':::be persistent, tenacious, strive::: :::ʕic'
+v:::ʕ/(:::ʀigw:::doak:::ʕigʷ:::(igw:::throw pl. objects::: :::ʕigʷ
+v:::ʕ/(:::ʀus:::doak:::ʕus(-t):::(us(-t):::be lost::: :::ʕus(-t) 
+v:::ʕ/(:::ʀuy:::doak:::ʕuy:::(uy:::coax, urge::: :::ʕuy
+v:::ʕ/(:::ʀuy:::doak:::ʕuy:::(uy:::waste, be extravagant::: :::ʕuy
+v:::ʕ/(:::ʀuy-tct:::doak:::ʕuy-čt:::(uy-cht:::mistreat old or helpless::: :::ʕuy-čt
+v:::ʕʷ/(w:::ṛʷax̣ʷ:::doak:::ʕʷax̣ʷ:::(waqhw:::stringlike object extends::: :::ʕʷax̣ʷ
+v:::ʕʷ/(w:::ṛʷä'<sup>ä</sup>:::doak:::ʕʷaʔ:::(wa':::reach into::: :::ʕʷaʔ
+v:::ʕʷ/(w:::ṛʷäm̕:::doak:::ʕʷɛm'(-t) :::(we'm(-t):::be enjoyable, wholesome::: :::ʕʷɛm'(-t) 
+v:::ʕʷ/(w:::ṛʷäl:::doak:::ʕʷɛl:::(wel:::dunk, dip to soak::: :::ʕʷɛl
+v:::ʕʷ/(w:::ṛʷäl-ä'<sup>ä</sup>l:::doak:::ʕʷɛl-ɛʔl:::(wel-e'l:::come to a lake::: :::ʕʷɛl-ɛʔl
+v:::ʕʷ/(w:::ṛʷäɬ:::doak:::ʕʷɛɫ(u-):::(weɫ(u-):::be of one piece::: :::ʕʷɛɫ(u-)
+v:::ʕʷ/(w:::ṛʷi'-ɩlc:::doak:::ʕʷi'-əlš:::(wi'-lsh:::vomit::: :::ʕʷi'-əlš
+v:::ʕʷ/(w:::ṛʷim:::doak:::ʕʷim:::(wim:::enjoy, relish::: :::ʕʷim
+v:::ʕʷ/(w:::ṛʷimic:::doak:::ʕʷimiš:::(wimish:::hurry on while moving::: :::ʕʷimiš
+v:::ʕʷ/(w:::ṛʷit̕.s:::doak:::ʕʷits:::(wits:::smile, smirk::: :::ʕʷits
+v:::h:::ha:::doak:::ha:::ha:::laugh loudly, haw-haw::: :::ha
+v:::h:::haq:::doak:::haq:::haq:::be space::: :::haq
+v:::h:::har:::doak:::har:::har:::snore::: :::har
+v:::h:::hä'in̕:::doak:::hɛʔin':::he'i'n:::eight::: :::hɛʔin'
+v:::h:::häp:::doak:::hɛp:::hep:::gobble::: :::hɛp
+v:::h:::hän:::doak:::hɛn:::hen:::be grayish in color::: :::hɛn
+v:::h:::häṛʷ:::doak:::hɛʕʷ:::he(w:::growl like bear::: :::hɛʕʷ
+v:::h:::hitcä'<sup>ä</sup>:::doak:::hičɛʔ:::hiche':::where?::: :::hičɛʔ
+v:::h:::hᴐi:::doak:::hɔi:::hoi:::cease::: :::hɔi
+v:::h:::hṛʷh:::doak:::hʕʷh:::h(wh:::frighten::: :::hʕʷh
+aci:::a:::aˑˑˑ:::doak:::a···:::a···:::with rising tone, oh!::: :::a···
+aci:::a:::aˑˑˑ:::doak:::a···:::a···:::with even tone, disapproval::: :::a···
+aci:::a:::ax̣iw̕ɬ:::doak:::ax̣iw'ɫ:::aqhi'wɫ:::now, today::: :::ax̣iw'ɫ
+aci:::a:::uts̕-ax̣íɬ:::doak:::uc'-ax̣íɫ:::uts'-aqh<u>i</u>ɫ:::because::: :::uc'-ax̣íɫ
+aci:::a:::äy̕níɬ:::doak:::sail:::nico:::english::: :::
+aci:::a:::pintc or pinttc:::doak:::pinč or pintč:::pinch:::always::: :::pinč or pintč
+aci:::a:::p̕unal̕:::doak:::p'unal':::p'una'l:::at least::: :::p'unal'
+aci:::a:::mäl̕:::doak:::mɛl':::me'l:::on near, touching, in addition to::: :::mɛl'
+aci:::a:::miyäɬ:::doak:::miyɛɫ:::miyeɫ:::too, very::: :::miyɛɫ
+aci:::a:::wax̣ᴇm:::doak:::wax̣əm':::waqh'm:::I told you so::: :::wax̣əm'
+aci:::a:::wihu'<sup>u</sup>:::doak:::wihuʔ:::wihu':::short distance::: :::wihuʔ
+aci:::a:::w̕ämnús:::doak:::w'ɛmnús:::'wemn<u>u</u>s:::in vain, useless::: :::w'ɛmnús
+aci:::a:::w̕im̕:::doak:::w'im':::'wi'm:::very near, almost::: :::w'im'
+aci:::a:::dä'äɬ:::doak:::dɛʔɛɫ:::de'eɫ:::exceptionally, surprisingly::: :::dɛʔɛɫ
+aci:::a:::tᴇmíc:::doak:::tɛmíš:::tem<u>i</u>sh:::just, only::: :::tɛmíš
+aci:::a:::twä:::doak:::twɛ:::twe:::with::: :::twɛ
+aci:::a:::tqilttc:::doak:::tqiltč:::tqiltch:::inland (hence east)::: :::tqiltč
+aci:::a:::nä<sup>ä</sup>m̕n̕us:::doak:::nɛm'n'us:::ne'm'nus:::I don't know::: :::nɛm'n'us
+aci:::a:::tsa'<sup>a</sup>x̣alp̕út:::doak:::caʔx̣alp'út:::tsa'qhalp'<u>u</u>t:::what's the use! (a very mean word)::: :::caʔx̣alp'út
+aci:::a:::tsmi'<sup>ɩ</sup>:::doak:::cmiʔ:::tsmi':::it was to be but is not::: :::cmiʔ
+aci:::a:::an-caricíɬ:::doak:::an-šarišíɫ:::an-sharish<u>i</u>ɫ:::upstream::: :::an-šarišíɫ
+aci:::a:::ci'<sup>ɩ</sup>mic:::doak:::šiʔmiš:::shi'mish:::anywhere, at random::: :::šiʔmiš
+aci:::a:::tcᴇn̕:::doak:::čən':::ch'n:::interrogative::: :::čən'
+aci:::a:::tc̕am̕:::doak:::č'am':::ch'a'm:::just::: :::č'am'
+aci:::a:::yäm-p:::doak:::yɛm-p:::yem-p:::forever::: :::yɛm-p
+aci:::a:::kum̕:::doak:::kum':::ku'm:::and::: :::kum'
+aci:::a:::kukúkʷ:::doak:::kukúkʷ:::kuk<u>u</u>kw:::in the other room::: :::kukúkʷ
+aci:::a:::kʷɩm̕ɬ:::doak:::kʷəm'ɫ:::kw'mɫ:::immediately::: :::kʷəm'ɫ
+aci:::a:::k̕ʷnä'<sup>ä</sup>:::doak:::k'ʷnɛʔ:::k'wne':::future::: :::k'ʷnɛʔ
+aci:::a:::k̕uk̕ʷníy̕ä'<sup>ä</sup>:::doak:::k'uk'ʷn'íy'ɛʔ:::k'uk'w'n<u>i</u>'ye':::in a short while::: :::k'uk'ʷn'íy'ɛʔ
+aci:::a:::k̕uk̕ʷi'<sup>ɩ</sup>ɬ:::doak:::k'uk'ʷiʔɫ :::k'uk'wi'ɫ:::in a short time::: :::k'uk'ʷiʔɫ 
+aci:::a:::xʷa'aɬ:::doak:::xʷaʔaɫ:::khwa'aɫ:::almost::: :::xʷaʔaɫ
+aci:::a:::xʷɩstc̕i:::doak:::xʷəč'i:::khwch'i:::interjection of admiration "how nice it is!"::: :::xʷəč'i
+aci:::a:::x̣umút:::doak:::x̣umút:::qhum<u>u</u>t:::of course, I suppose::: :::x̣umút
+aci:::a:::x̣ämä'<sup>ä</sup>tc:::doak:::x̣ɛ́mɛʔč:::qh<u>e</u>me'ch:::just you dare!::: :::x̣ɛ́mɛʔč
+aci:::a:::x̣äl:::doak:::x̣ɛl:::qhel:::also, likewise::: :::x̣ɛl
+aci:::a:::x̣älä'<sup>ä</sup>:::doak:::x̣ɛlɛʔ:::qhele':::might, used in sense of expecting something unfavorable::: :::x̣ɛlɛʔ
+aci:::a:::x̣iɬ:::doak:::x̣iɫ:::qhiɫ:::might, used in sense of possibility of any kind::: :::x̣iɫ
+aci:::a:::ɬ:::doak:::ɫ:::ɫ:::connective::: :::ɫ
+aci:::a:::ɬuw̕ä:::doak:::ɫuw'ɛ:::ɫu'we:::that near third person or remote::: :::ɫuw'ɛ
+aci:::a:::ɬᴐqʷ:::doak:::ɫɔqʷ:::ɫoqw:::and also::: :::ɫɔqʷ
+aci:::a:::hɩɬ:::doak:::həɫ:::hɫ:::general connective::: :::həɫ
+n:::a:::*a<sup>a</sup>pᴐˊtar:::doak:::apótar:::ap<u>o</u>tar:::apostle::: :::apótar
+n:::a:::*apls:::doak:::apls:::apls:::apple::: :::apls
+n:::a:::*anc:::doak:::anš:::ansh:::angel::: :::anš
+n:::a:::asqʷ:::doak:::asqʷ:::asqw:::son::: :::asqʷ
+n:::a:::atcatcn-áɬqʷ:::doak:::ačačn-áɫqʷ:::achachn-<u>a</u>ɫqw:::juniper::: :::ačačn-áɫqʷ
+n:::a:::ay̕x̣:::doak:::ay'x̣:::a'yqh:::crayfish::: :::ay'x̣
+n:::a:::y̕-alstq:::doak:::y'-alstq:::'y-alstq:::summer::: :::y'-alstq
+n:::a:::aɬdáräntc:::doak:::aɫdárɛnč:::aɫd<u>a</u>rench:::month, sun::: :::aɫdárɛnč
+n:::a:::aɬq̕íts̕äntc:::doak:::aɫq'íc'ɛnč:::aɫq'<u>i</u>ts'ench:::snake::: :::aɫq'íc'ɛnč
+n:::a:::aɬq̕ʷäˊt̕ut:::doak:::aɫq'ʷɛ́t'ut:::aɫq'w<u>e</u>t'ut:::Plummer (place name)::: :::aɫq'ʷɛ́t'ut
+n:::ɛ/e:::*äijíp:::doak:::ɛiji'p:::eiji'p:::Egypt::: :::ɛiji'p
+n:::ɛ/e:::ätx̣ʷä'<sup>ä</sup>:::doak:::ɛtx̣ʷɛʔ:::etqhwe':::camas::: :::ɛtx̣ʷɛʔ
+n:::ɛ/e:::atcs-ät̕qᴇt:::doak:::sail:::nico:::english::: :::
+n:::ɛ/e:::ästcítcä'<sup>ä</sup>:::doak:::ačs-ɛt'qət:::achs-et'qt:::day time::: :::ačs-ɛt'qət
+n:::ɛ/e:::reichard:::ɛsčíčɛʔ:::ɛsčíčɛʔ:::esch<u>i</u>che':::horse, pet, domestic animal::: :::ɛsčíčɛʔ
+n:::ɛ/e:::äɬṛʷäts̕:::doak:::ɛɫʕʷɛc':::eɫ(wets':::magpie::: :::ɛɫʕʷɛc'
+n:::i:::i'i:::doak:::iʔi:::i'i:::turtledove::: :::iʔi
+n:::i:::ík̕ʷul:::doak:::i'k'ʷul:::i'k'wul:::fish roe::: :::i'k'ʷul
+n:::i:::ä'íxʷä'<sup>ä</sup>:::doak:::ɛʔíxʷɛʔ:::e'<u>i</u>khwe':::mother's sister (dim.)::: :::ɛʔíxʷɛʔ
+n:::i:::iltc:::doak:::ilč:::ilch:::kinnikinnick berry::: :::ilč
+n:::u, ɔ/o:::tcs-ups:::doak:::čs-ups:::chs-ups:::tail::: :::čs-ups
+n:::u, ɔ/o:::usä'<sup>ä</sup>:::doak:::usɛʔ:::use':::egg::: :::usɛʔ
+n:::u, ɔ/o:::tc̕i<sup>ɩ</sup>y̕-úkʷä'<sup>ä</sup>:::doak:::č'iy'-úkʷɛʔ:::ch'i'y-<u>u</u>kwe':::w.s. younger brother::: :::č'iy'-úkʷɛʔ
+n:::u, ɔ/o:::*buˑlɩˑ:::doak:::bu·lə·:::bu·l·:::bull::: :::bu·lə·
+n:::u, ɔ/o:::*s-pa<sup>a</sup>yᴐˊlụmc:::doak:::s-payóləmš:::s-pay<u>o</u>lmsh:::Spanish::: :::s-payóləmš
+n:::u, ɔ/o:::s-pápx̣-ɬtsä'<sup>ä</sup>:::doak:::s-pápx̣-ɫc'ɛʔ:::s-p<u>a</u>pqh-ɫts'e':::ermine::: :::s-pápx̣-ɫc'ɛʔ
+n:::u, ɔ/o:::*patáq:::doak:::patáq:::pat<u>a</u>q:::potato::: :::patáq
+n:::u, ɔ/o:::päˊwpu'ɩc:::doak:::pɛ́wpuʔəš:::p<u>e</u>wpu'sh:::tin oil can::: :::pɛ́wpuʔəš
+n:::u, ɔ/o:::s-päˊtäp:::doak:::s-pɛ́tɛp:::s-p<u>e</u>tep:::small gopher::: :::s-pɛ́tɛp
+n:::u, ɔ/o:::pätstcɩlä:::doak:::pɛcčəlɛ:::petschle:::leaf, cabbage::: :::pɛcčəlɛ
+n:::u, ɔ/o:::päkut:::doak:::pɛkut:::pekut:::skin, hide::: :::pɛkut
+n:::u, ɔ/o:::päxpụxʷ:::doak:::pɛxpəxʷ:::pekhpkhw:::pekhpkhw::: :::pɛxpəxʷ
+n:::u, ɔ/o:::pípä'<sup>ä</sup>:::doak:::pípɛʔ:::p<u>i</u>pe':::father::: :::pípɛʔ
+n:::u, ɔ/o:::*piwyä:::doak:::piwyɛ:::piwye:::camas of Nez Perce country::: :::piwyɛ
+n:::u, ɔ/o:::s-pinttc:::doak:::s-pintč:::s-pintch:::year::: :::s-pintč
+n:::u, ɔ/o:::pítsä'<sup>ä</sup>:::doak:::pícɛʔ:::p<u>i</u>tse':::root digger::: :::pícɛʔ
+n:::u, ɔ/o:::s-pítcs-mᴇn:::doak:::s-píčs-mən:::s-p<u>i</u>chs-mn:::pestle::: :::s-píčs-mən
+n:::u, ɔ/o:::s-píläm:::doak:::s-pílɛm:::s-p<u>i</u>lem:::level land::: :::s-pílɛm
+n:::u, ɔ/o:::its-pu'<sup>u</sup>:::doak:::ic-puʔs:::its-pu's:::desire, heart::: :::ic-puʔs
+n:::u, ɔ/o:::s-pum:::doak:::s-pum:::s-pum:::fur, feathers (on animal)::: :::s-pum
+n:::u, ɔ/o:::s-puɬt:::doak:::s-puɫt:::s-puɫt:::feathers (loose)::: :::s-puɫt
+n:::u, ɔ/o:::pul̕yä:::doak:::pul'yɛ:::pu'lye:::gopher::: :::pul'yɛ
+n:::u, ɔ/o:::pulya<sup>a</sup>hal̕:::doak:::pulyahal':::pulyaha'l:::mole::: :::pulyahal'
+n:::u, ɔ/o:::s-pᴐtst:::doak:::s-pɔtc:::s-potts:::scab, sore, excrement::: :::s-pɔtc
+n:::u, ɔ/o:::pᴐˊl-pᴐlq-ᴇn:::doak:::pól-pɔlq-ən:::p<u>o</u>l-polq-n:::thimbleberry::: :::pól-pɔlq-ən
+n:::u, ɔ/o:::s-pɩt̕áswäl:::doak:::s-pət'áswɛl:::s-pt'<u>a</u>swel:::trout::: :::s-pət'áswɛl
+n:::u, ɔ/o:::s-pᴇtw̕ínuxʷ:::doak:::s-pətw'ínuxʷ:::s-pt'w<u>i</u>nukhw:::head of a nest, brood, house-hold::: :::s-pətw'ínuxʷ
+n:::u, ɔ/o:::s-pᴇsáiyä:::doak:::s-pəsáiyɛ:::s-ps<u>a</u>iye:::folly, error::: :::s-pəsáiyɛ
+n:::u, ɔ/o:::*pus:::doak:::pus:::pus:::cat::: :::pus
+n:::u, ɔ/o:::púsä'<sup>ä</sup>:::doak:::púsɛʔ:::p<u>u</u>se':::father's brother::: :::púsɛʔ
+n:::p':::s-p̕an̕x̣:::doak:::s-p'an'x̣:::s-p'a'nqh:::woven bag::: :::s-p'an'x̣
+n:::p':::s-p̕árk̕ʷ-alqs:::doak:::s-p'árk' w-alqs:::s-p'<u>a</u>rk':::turtle, pulley::: :::s-p'árk' w-alqs
+n:::p':::p̕ästa:::doak:::p'ɛsta:::p'esta:::snipe::: :::p'ɛsta
+n:::p':::p̕ästä'<sup>ä</sup>:::doak:::p'ɛstɛʔ:::p'este':::nighthawk::: :::p'ɛstɛʔ
+n:::p':::p̕ätc̕ᴇn̕:::doak:::p'ɛč'ən':::p'ech''n:::lynx::: :::p'ɛč'ən'
+n:::p':::p̕äˊkʷlä'<sup>ä</sup>:::doak:::p'ɛ́kʷleʔ:::p'<u>e</u>kwle':::ball::: :::p'ɛ́kʷleʔ
+n:::p':::s-p̕äˊxʷ-äntc:::doak:::s-p'ɛ́xʷ-ɛnč:::s-p'<u>e</u>khw-ench:::hog fennel root::: :::s-p'ɛ́xʷ-ɛnč
+n:::p':::s-p̕ít̕äm:::doak:::s-p'ít'ɛm:::s-p'<u>i</u>t'em:::bitterroot::: :::s-p'ít'ɛm
+n:::p':::s-p̕í-ɬts̕ä'<sup>ä</sup>:::doak:::s-p'í-ɫc'ɛʔ:::s-p'<u>i</u>-ɫts'e':::elk::: :::s-p'í-ɫc'ɛʔ
+n:::m:::matus:::doak:::matus:::matus:::camas (piwyɛ) mush::: :::matus
+n:::m:::masmᴇs:::doak:::masmɛs:::masmes:::a plant which smells awful when boiling::: :::masmɛs
+n:::m:::máts̕-uɬt:::doak:::mác'-uɫt:::m<u>a</u>ts'-uɫt:::pus::: :::mác'-uɫt
+n:::m:::mats̕p:::doak:::mac'p:::mats'p:::bee, wasp::: :::mac'p
+n:::m:::s-max̣í'<sup>ɩ</sup>tcn̕:::doak:::s-max̣íʔčn':::s-maqh<u>i</u>'ch'n:::grizzly bear::: :::s-max̣íʔčn'
+n:::m:::malqänúps:::doak:::malqɛnúps:::malqen<u>u</u>ps:::golden eagle::: :::malqɛnúps
+n:::m:::s-málq-ᴇn:::doak:::s-málq-ən:::s-m<u>a</u>lq-n:::cooked black moss::: :::s-málq-ən
+n:::m:::mimc or minc:::doak:::mimš or minš:::mimsh:::box::: :::mimš
+n:::m:::mít̕t̕c̕ädä'<sup>ä</sup>:::doak:::mit'č'ɛdɛʔ:::mit'ch'ede':::blood::: :::mit'č'ɛdɛʔ
+n:::m:::minátcalqs:::doak:::mináčalqs:::min<u>a</u>chalqs:::buzzard::: :::mináčalqs
+n:::m:::s-míy̕äm:::doak:::s-míy'ɛm:::s-m<u>i</u>'yem:::woman, wife::: :::s-míy'ɛm
+n:::m:::mul:::doak:::mul:::mul:::butter::: :::mul
+n:::m:::hɩn-múlcäntc:::doak:::hən-múlšenč:::hn-m<u>u</u>lshench:::beaver::: :::hən-múlšenč
+n:::m:::s-mul̕-mᴇn:::doak:::s-mul'-mən:::s-mu'l-mn:::war spear::: :::s-mul'-mən
+n:::m:::*muh:::doak:::muh:::muh:::cow::: :::muh
+n:::m:::mᴐˊt̕us:::doak:::mót'us:::m<u>o</u>t'us:::kidney::: :::mót'us
+n:::m:::ä-sɩn-mɩsmɩs-íw̕äs:::doak:::ɛ-sən-məsməs-íw'ɛs:::e-sn-msms-<u>i</u>'wes:::yew-wood, heart of yew, bow-wood::: :::ɛ-sən-məsməs-íw'ɛs
+n:::m:::s-mɩyíw:::doak:::s-məyíw:::s-my<u>i</u>w:::coyote::: :::s-məyíw
+n:::m:::s-mɩɬítc:::doak:::s-məɫíč:::s-mɫ<u>i</u>ch:::salmon::: :::s-məɫíč
+n:::m:::s-m̕äˊ<sup>ä</sup>m̕ín̕äp:::doak:::s-m'ɛʔm'ín'ɛp:::s-'me'm<u>i</u>'nep:::toad::: :::s-m'ɛʔm'ín'ɛp
+n:::m:::m̕äl̕ä:::doak:::m'ɛl'ɛ:::'me'le:::bait::: :::m'ɛl'ɛ
+n:::m:::s-m̕-m̕útscᴇn:::doak:::s-m'-m'úcšən':::s-'m-'m<u>u</u>tssh'n:::female animal, mare::: :::s-m'-m'úcšən'
+n:::m:::s-wa'ítn̕:::doak:::s-waʔítn':::s-wa'<u>i</u>t'n:::spring of water::: :::s-waʔítn'
+n:::m:::wáx̣-iɬp:::doak:::wáx̣-iɫp:::w<u>a</u>qh-iɫp:::dogwood::: :::wáx̣-iɫp
+n:::w, w':::wartc:::doak:::warč:::warch:::frog::: :::warč
+n:::w, w':::wä'<sup>ä</sup>wi'ítc:::doak:::wɛʔwiʔíč:::we'wi'<u>i</u>ch:::whippoorwill::: :::wɛʔwiʔíč
+n:::w, w':::wäsx̣ax̣:::doak:::wɛsx̣ax̣:::wesqhaqh:::robin::: :::wɛsx̣ax̣
+n:::w, w':::wähíma':::doak:::wɛhíma':::weh<u>i</u>ma':::Nez Perce people and country::: :::wɛhíma'
+n:::w, w':::s-wiwaláqᴇn:::doak:::s-wiwaláqən:::s-wiwal<u>a</u>qn:::Whispering-in-branches (place-name)::: :::s-wiwaláqən
+n:::w, w':::wicú'us:::doak:::wišúʔus:::wish<u>u</u>'us:::black-tailed deer::: :::wišúʔus
+n:::w, w':::wᴐptú:::doak:::wɔptú:::wopt<u>u</u>:::potatoes that grow in Yakima and Nez Perce country::: :::wɔptú
+n:::w, w':::wụlwụlím:::doak:::wəlwəlím:::wlwl<u>i</u>m:::money, valuables::: :::wəlwəlím
+n:::w, w':::s-w̕a'<sup>a</sup>:::doak:::s-w'aʔ:::s-'wa':::cougar::: :::s-w'aʔ
+n:::w, w':::w̕ụl̕w̕ụl̕ím̕:::doak:::w'əlw'əl'ím:::'w'lw'l<u>i</u>m:::iron, knife::: :::w'əlw'əl'ím
+n:::d:::däˊctcägwä:::doak:::dɛ́ščɛgʷɛ:::d<u>e</u>shchegwe:::husband's brother, sister's husband::: :::dɛ́ščɛgʷɛ
+n:::d:::däɬ-äɬp:::doak:::dɛɫ-ɛɫp:::deɫ-eɫp:::poplar::: :::dɛɫ-ɛɫp
+n:::d:::dᴇ-däl̕dᴇl̕:::doak:::də-dɛ́l'dəl':::d-d<u>e</u>'ld'l:::bush (dim.)::: :::də-dɛ́l'dəl'
+n:::d:::däˊl̕-äɬp:::doak:::dɛ́l'-əɫp:::d<u>e</u>'l-ɫp:::willow tree::: :::dɛ́l'-əɫp
+n:::d:::tc-däl̕-díl̕p:::doak:::č-dɛl'-díl'p:::ch-de'l-d<u>i</u>'lp:::bat, chickenhawk::: :::č-dɛl'-díl'p
+n:::d:::s-dílu':::doak:::s-dílu:::s-d<u>i</u>lu:::switch::: :::s-dílu
+n:::d:::dupᴇn:::doak:::dupən:::dupn:::lasso::: :::dupən
+n:::d:::dúmtsᴇn:::doak:::dúmcən:::d<u>u</u>mtsn:::relative-friend::: :::dúmcən
+n:::d:::dúɬduɬp:::doak:::dúɫduɫp:::d<u>u</u>ɫduɫp :::trees of the poplar family::: :::dúɫduɫp
+n:::d:::dɩmínä'<sup>ä</sup>:::doak:::dəmínɛʔ:::dm<u>i</u>ne':::nest::: :::dəmínɛʔ
+n:::t:::s-tax̣-täˊx̣-al̕tct:::doak:::s-tax̣-tɛ́x̣-al'čt:::s-taqh-t<u>e</u>qh-a'lcht:::doll::: :::s-tax̣-tɛ́x̣-al'čt
+n:::t:::tᴇtaqʷ:::doak:::tətaqʷ:::ttaqw:::gulch, hollow::: :::tətaqʷ
+n:::t:::s-taräˊq-cᴇn:::doak:::s-tarɛ́q-šən:::s-tar<u>e</u>q-shn:::mudhen::: :::s-tarɛ́q-šən
+n:::t:::s-tä<sup>ä</sup>m-ílgwäs:::doak:::s-tɛm-ílgʷɛs:::s-tem-<u>i</u>lgwes:::relative::: :::s-tɛm-ílgʷɛs
+n:::t:::sɩn-tä'úl̕ụmc:::doak:::sən-tɛʔúləmš:::sn-te'<u>u</u>lmsh:::Spokane::: :::sən-tɛʔúləmš
+n:::t:::s-täˊpax̣ʷ:::doak:::s-tɛ́pax̣ʷ:::s-t<u>e</u>paqhw:::saliva::: :::s-tɛ́pax̣ʷ
+n:::t:::s-tc-täm̕p:::doak:::s-č-tɛm'p:::s-ch-te'mp:::cloud::: :::s-č-tɛm'p
+n:::t:::s-tälᴇm:::doak:::s-təɫəm:::s-tɫm:::boat::: :::s-təɫəm
+n:::t:::s-ti'<sup>ɩ</sup>:::doak:::s-tiʔ:::s-ti':::thing::: :::s-tiʔ
+n:::t:::s-tim̕:::doak:::s-tim':::s-ti'm:::what, something::: :::s-tim'
+n:::t:::tiwun-ɬtsäˊ<sup>ä</sup>  [sic]:::doak:::tiwun-ɫcɛ:::tiwun-ɫts<u>e</u>:::doe::: :::tiwun-ɫcɛ
+n:::t:::tíwämᴇn:::doak:::tíwɛmən:::t<u>i</u>wemn:::plaything of tallow (tiw indulge)::: :::tíwɛmən
+n:::t:::tintc:::doak:::tinč:::tinch:::sinew, muscle::: :::tinč
+n:::t:::s-titctsxʷ:::doak:::s-tičcsxʷ:::s-tichtsskhw:::red willowberry (?)(colloquial translation)::: :::s-tičcsxʷ
+n:::t:::tikʷä'<sup>ä</sup>:::doak:::tikʷɛʔ:::tikwe':::father's sister::: :::tikʷɛʔ
+n:::t:::tíxʷtstc:::doak:::tixʷcč:::tikhwtsch:::tongue::: :::tixʷcč
+n:::t:::túpän̕:::doak:::túpɛn':::t<u>u</u>pe'n:::spider::: :::túpɛn'
+n:::t:::tụm:::doak:::təm:::tm:::corpse, dead::: :::təm
+n:::t:::s-tum̕c:::doak:::s-tum'š:::s-tu'msh:::friend (used by Coyote and Fox only)::: :::s-tum'š
+n:::t:::tunc:::doak:::tunš:::tunsh:::m.s. sister's child, brother's child::: :::tunš
+n:::t:::tᴐt:::doak:::tɔt:::tot:::pet animal::: :::tɔt
+n:::t:::tᴇmᴐˊl̕x̣:::doak:::təmól'x̣:::tm<u>o</u>'lqh:::hail::: :::təmól'x̣
+n:::t:::tɩtw̕it:::doak:::tətw'it :::tt'wit:::youth, young boy::: :::tətw'it 
+n:::t:::s-tiyítc-cᴇn:::doak:::s-tiyíč-šən:::s-tiy<u>i</u>ch-shn:::killdeer::: :::s-tiyíč-šən
+n:::t:::tɩtm̕ixʷ:::doak:::tətm'ixʷ:::tt'mikhw:::animal::: :::tətm'ixʷ
+n:::t:::twi'<sup>ɩ</sup>:::doak:::twiʔ:::twi':::the poor thing!::: :::twiʔ
+n:::t:::tqᴇmíc:::doak:::tqəmíš:::tqm<u>i</u>sh:::snowbird (?)::: :::tqəmíš
+n:::t:::tʀin:::doak:::tʕin:::t(in:::antelope::: :::tʕin
+n:::t':::t̕aqt̕ítcn:::doak:::t'aqt'íčn:::t'aqt'<u>i</u>chn:::game, kill::: :::t'aqt'íčn
+n:::t':::t̕ᴇt̕aqʷín̕:::doak:::t'ət'aqʷín':::t't'aqw<u>i</u>'n:::one of the snipes::: :::t'ət'aqʷín'
+n:::t':::s-t̕árt̕ari'<sup>ɩ</sup>m:::doak:::s-t'árt'ariʔm:::s-t'<u>a</u>rt'ari'm:::thunder (perhaps his name)::: :::s-t'árt'ariʔm
+n:::t':::t̕ä'<sup>ä</sup>kʷílc:::doak:::t'ɛʔkʷílš:::t'e'kw<u>i</u>lsh:::shaman::: :::t'ɛʔkʷílš
+n:::t':::s-t̕ädä'<sup>ä</sup>:::doak:::s-t'ɛdɛʔ:::s-t'ede':::hay, grass, fodder::: :::s-t'ɛdɛʔ
+n:::t':::t̕ädä'<sup>ä</sup>:::doak:::t'ɛdɛʔ:::t'ede':::canoe::: :::t'ɛdɛʔ
+n:::t':::t̕äˊtc̕tɩtc̕:::doak:::tɛ́č'təč':::t<u>e</u>ch'tch':::blackbird::: :::tɛ́č'təč'
+n:::t':::s-t̕iitc̕ɩmíc:::doak:::s-t'iičəmíš:::s-t'iichm<u>i</u>sh:::Virgin Mary::: :::s-t'iičəmíš
+n:::t':::s-t̕tím-tcä'<sup>ä</sup>:::doak:::s-t'tím-čɛʔ:::s-t't<u>i</u>m-che':::daughter::: :::s-t'tím-čɛʔ
+n:::t':::t̕ínä'<sup>ä</sup>:::doak:::t'ínɛʔ:::t'<u>i</u>ne':::outer ear::: :::t'ínɛʔ
+n:::t':::t̕its̕:::doak:::t'ic':::t'its':::gum::: :::t'ic'
+n:::t':::s-t̕íy-äɬtsä'<sup>ä</sup>:::doak:::s-t'íy-ɛɫcɛʔ:::s-t'<u>i</u>y-eɫtse':::caribou::: :::s-t'íy-ɛɫcɛʔ
+n:::t':::t̕úpyä'<sup>ä</sup>:::doak:::t'úpyɛʔ:::t'<u>u</u>pye':::great grandfather::: :::t'úpyɛʔ
+n:::t':::s-t̕únɬts̕ä'<sup>ä</sup>:::doak:::s-t'únɫc'ɛʔ:::s-t'<u>u</u>nɫts'e':::mule deer::: :::s-t'únɫc'ɛʔ
+n:::t':::t̕us:::doak:::t'us:::t'us:::marrow::: :::t'us
+n:::t':::tc-t̕uxʷäˊ'us:::doak:::č-t'uxʷɛ́ʔus:::ch-t'ukhw<u>e</u>'us:::fat around stomach of animal::: :::č-t'uxʷɛ́ʔus
+n:::t':::t̕uxʷän:::doak:::t'uxʷɛn:::t'ukhwen:::jointgrass::: :::t'uxʷɛn
+n:::t':::s-t̕ᴐpqs:::doak:::s-t'ɔpqs:::s-t'opqs:::thread::: :::s-t'ɔpqs
+n:::t':::an-t̕ᴇl̕ánä'<sup>ä</sup>:::doak:::an-t'əl'ánɛʔ:::an-t''l<u>a</u>ne':::wolf::: :::an-t'əl'ánɛʔ
+n:::t':::hɩn-t̕ụk̕w̕í'<sup>ɩ</sup>sen [sic]:::doak:::hən-t'ək'ʷ'-íʔsen:::hn-t'k'w-<u>i</u>'sen:::seed, pit::: :::hən-t'ək'ʷ'-íʔsen
+n:::t':::s-t̕am̕á (ltụmc):::doak:::s-t'am'á:::s-t'a'm<u>a</u>:::(ltəmš) cow::: :::s-t'am'á
+n:::n:::nasx̣á'ax̣:::doak:::nasx̣áʔax̣:::nasqh<u>a</u>'aqh:::m.s. father-in-law::: :::nasx̣áʔax̣
+n:::n:::nadjarᴐˊ:::doak:::naǰaró:::najar<u>o</u>:::scoundrel, rascal::: :::naǰaró
+n:::n:::naryä:::doak:::naryɛ:::narye:::great great grandparent::: :::naryɛ
+n:::n:::näɬtsítc:::doak:::nɛɫcíč:::nɛɫcíč:::m.s. mother-in-law::: :::nɛɫcíč
+n:::n:::s-nínä'<sup>ä</sup>:::doak:::s-nínɛʔ:::s-n<u>i</u>ne':::owl::: :::s-nínɛʔ
+n:::n:::s-nitc̕-ɬxʷ:::doak:::s-nič'-ɫxʷ:::s-nich'-ɫkhw:::son-in-law (nič' cut; -lxʷ house)::: :::s-nič'-ɫxʷ
+n:::n:::núnä'<sup>ä</sup>:::doak:::núnɛʔ:::n<u>u</u>ne':::mother::: :::núnɛʔ
+n:::n:::s-nᴐs:::doak:::s-nɔs:::s-nos:::snot::: :::s-nɔs
+n:::n:::nᴐx̣nᴐx̣:::doak:::nɔx̣nɔx̣:::noqhnoqh:::spouse::: :::nɔx̣nɔx̣
+n:::s:::sättc:::doak:::sɛtč:::setch:::paunch::: :::sɛtč
+n:::s:::*sanpiyär:::doak:::sanpiyɛr:::sanpiyer:::St. Peter::: :::sanpiyɛr
+n:::s:::*sanpᴐl:::doak:::sanpɔl:::sanpol:::St. Paul::: :::sanpɔl
+n:::s:::*santiglis:::doak:::santiglis:::santiglis:::Holy Church::: :::santiglis
+n:::s:::sáx̣ʷ-ɬkʷä'<sup>ä</sup>:::doak:::sáxʷ-ɫkʷɛʔ:::s<u>a</u>khw-ɫkwe':::vein::: :::sáxʷ-ɫkʷɛʔ
+n:::s:::sarkʷs:::doak:::sarkʷs:::sarkws:::pine-squirrel::: :::sarkʷs
+n:::s:::sar̕ítcn̕:::doak:::sar'íčn':::sa'r<u>i</u>ch'n:::squirrel::: :::sar'íčn'
+n:::s:::atc-sät̕qᴇt:::doak:::ač-sɛt'qət:::ach-set'qt:::time::: :::ač-sɛt'qət
+n:::s:::hɩn-sätc̕-ᴇntɩs:::doak:::hən-sɛč'-əntəs:::hn-sech'-nts:::river::: :::hən-sɛč'-əntəs
+n:::s:::sätc̕-ätct:::doak:::sɛč'-ɛčt:::sech'-echt:::black moss (raw)::: :::sɛč'-ɛčt
+n:::s:::si'<sup>ɩ</sup>stᴇm:::doak:::siʔstəm:::si'stm:::m.s. brother's wife, wife's sister::: :::siʔstəm
+n:::s:::sípᴇm:::doak:::sípəm:::s<u>i</u>pm:::daughter-in-law::: :::sípəm
+n:::s:::sisí'<sup>ɩ</sup>:::doak:::sisíʔ:::sis<u>i</u>':::brother's brother (dim.)::: :::sisíʔ
+n:::s:::siw̕s:::doak:::siw's:::si'ws:::groundhog, prairie dog::: :::siw's
+n:::s:::sit, sítkʷ:::doak:::sit, sítkʷ:::sit, s<u>i</u>tkw:::winter::: :::sit, sítkʷ
+n:::s:::sítqaps:::doak:::sítqaps:::s<u>i</u>tqaps:::spring season::: :::sítqaps
+n:::s:::sittc:::doak:::sitč:::sitch:::belly::: :::sitč
+n:::s:::sintsä'<sup>ä</sup>:::doak:::sincɛʔ:::sintse':::m.s younger brother::: :::sincɛʔ
+n:::s:::sitc̕:::doak:::sič':::sich':::ground squirrel::: :::sič'
+n:::s:::siyᴐˊl-alqʷ:::doak:::siyól-alqʷ:::siy<u>o</u>l-alqw:::stick::: :::siyól-alqʷ
+n:::s:::sikʷä'<sup>ä</sup>:::doak:::sikʷɛʔ:::sikwe':::water::: :::sikʷɛʔ
+n:::s:::silä'<sup>ä</sup>:::doak:::silɛʔ:::sile':::mother's father::: :::silɛʔ
+n:::s:::su<sup>u</sup>yäˊpụmc:::doak:::suyɛ́pəmš:::suy<u>e</u>pmsh:::white man::: :::suyɛ́pəmš
+n:::s:::sut̕ä'<sup>ä</sup>sút̕ä:::doak:::sut'ɛʔsút'ɛ:::sut'e's<u>u</u>t'e:::rubber::: :::sut'ɛʔsút'ɛ
+n:::s:::susᴇn̕:::doak:::susən':::sus'n:::spoon::: :::susən'
+n:::s:::suxʷ-änäy̕:::doak:::suxʷ-ɛnɛy':::sukhw-ene'y:::rice, ant::: :::suxʷ-ɛnɛy'
+n:::s:::*sᴐltäs:::doak:::sɔltɛs:::soltes:::soldier::: :::sɔltɛs
+n:::c/ts:::s-tsá'aqʷ:::doak:::s-cáʔaqʷ:::s-ts<u>a</u>'aqw:::fall, autumn::: :::s-cáʔaqʷ
+n:::c/ts:::*tsánmᴇn:::doak:::cánmən:::ts<u>a</u>nmn:::Chinaman::: :::cánmən
+n:::c/ts:::s-tsaqụm:::doak:::s-caqəm:::s-tsaqm:::strawberry::: :::s-caqəm
+n:::c/ts:::tsätxʷ:::doak:::cɛtxʷ:::tsetkhw:::house::: :::cɛtxʷ
+n:::c/ts:::hɩn-tsäˊx̣ut:::doak:::hən-cáx̣ut:::hn-ts<u>a</u>qhut:::stream river::: :::hən-cáx̣ut
+n:::c/ts:::s-tsí'<sup>ɩ</sup>läɬ:::doak:::s-cíʔlɛɫ:::s-ts<u>i</u>'leɫ:::substitute::: :::s-cíʔlɛɫ
+n:::c/ts:::tsicps:::doak:::cišps:::tsishps:::fisher::: :::cišps
+n:::c/ts:::tsutsyu'<sup>u</sup>:::doak:::cucyuʔ:::tsutsyu':::firetongs::: :::cucyuʔ
+n:::c/ts:::tsɩtsíy̕ä'<sup>ä</sup>:::doak:::cəcíy'ɛʔ:::tsts<u>i</u>'ye':::w.s. younger speaker::: :::cəcíy'ɛʔ
+n:::c/ts:::s-tsumt:::doak:::s-cumt:::s-tsumt:::going or coming soon::: :::s-cumt
+n:::c/ts:::tsuɬum:::doak:::cuɫum:::tsuɫum:::buffalo::: :::cuɫum
+n:::c/ts:::ä-tsᴐm̕ɬxʷ:::doak:::ɛ-cɔm'ɫxʷ:::e-tso'mɫkhw:::long house::: :::ɛ-cɔm'ɫxʷ
+n:::c/ts:::a-tsᴇtsᴐqálipä:::doak:::ɛ-cɔm'ɫxʷ:::a-cəcɔqálipɛ:::red nits::: :::ɛ-cɔm'ɫxʷ
+n:::c/ts:::ä-tsụxʷ-tsụxʷ-wᴇy̕ípä'<sup>ä</sup>:::doak:::ɛ-cəxʷ-cəxʷ-wəyípɛʔ:::e-tskhw-tskhw-wy<u>i</u>pe':::rosehips::: :::ɛ-cəxʷ-cəxʷ-wəyípɛʔ 
+n:::c/ts:::s-ts̕am̕:::doak:::s-cam':::s-tsa'm:::bone, be bony::: :::s-cam'
+n:::c'/ts':::ts̕án̕ts̕ᴇn̕:::doak:::c'án'c'ən':::ts'<u>a</u>'nts''n:::grasshopper::: :::c'án'c'ən'
+n:::c'/ts':::ts̕áq̕-äɬp:::doak:::c'áq'-ɛɫp:::ts'<u>a</u>q'-eɫp:::fir::: :::c'áq'-ɛɫp
+n:::c'/ts':::ts̕ax̣yú'<sup>u</sup>ts̕ᴇn:::doak:::c'ax̣yúʔc'ən:::ts'aqhy<u>u</u>'ts'n:::mink::: :::c'ax̣yúʔc'ən
+n:::c'/ts':::ts̕álus:::doak:::c'álus:::ts'<u>a</u>lus:::kingfisher::: :::c'álus
+n:::c'/ts':::a-ts̕áṛʷläp:::doak:::a-c'áʕʷlɛp:::a-ts'<u>a</u>(wlep:::punk::: :::a-c'áʕʷlɛp
+n:::c'/ts':::s-ts̕ä<sup>ä</sup>w̕-íɬcᴇn̕:::doak:::s-c'ɛw'-íɫšən':::s-ts'e'w-<u>i</u>ɫsh'n:::splinter-leg::: :::s-c'ɛw'-íɫšən'
+n:::c'/ts':::ts̕äkukʷ:::doak:::c'ɛkukʷ:::ts'ekukw:::elderberry::: :::c'ɛkukʷ
+n:::c'/ts':::hɩn-ts̕älcalps:::doak:::hən-c'ɛlšalps:::hn-ts'elshalps:::hardtack (a "story" word)::: :::hən-c'ɛlšalps
+n:::c'/ts':::ts̕i'<sup>ɩ</sup>:::doak:::c'iʔ:::ts'i':::deer::: :::c'iʔ
+n:::c'/ts':::s-ts̕ict:::doak:::s-c'išt:::s-ts'isht:::m.s wife's brother, sister's husband::: :::s-c'išt 
+n:::c'/ts':::ts̕íxʷts̕ụxʷ:::doak:::c'íxʷc'əxʷ:::ts'<u>i</u>khwts'khw:::fishhawk::: :::c'íxʷc'əxʷ
+n:::c'/ts':::s-ts̕ú'<sup>u</sup>-cᴇn̕:::doak:::s-c'úʔ-šən:::s-ts'<u>u</u>'-shn:::foot (of slaughtered animal)::: :::s-c'úʔ-šən
+n:::c'/ts':::s-ts̕ᴐm̕̕-ts̕ᴐm̕̕-ɬt:::doak:::s-c'óm'-c'ɔm'-ɫt:::s-ts'<u>o</u>'m-ts'o'm-ɫt:::boil::: :::s-c'óm'-c'ɔm'-ɫt
+n:::c'/ts':::s-c-ts̕ᴇs-lúsä'<sup>ä</sup>:::doak:::s-š-c'əs-lúsɛʔ:::s-sh-ts's-l<u>u</u>se':::hail::: :::s-š-c'əs-lúsɛʔ
+n:::š/sh:::cämän̕:::doak:::šɛmɛn':::sheme'n:::enemy::: :::šɛmɛn'
+n:::š/sh:::s-cät̕ᴇt:::doak:::s-šɛt'ət:::s-shet't :::cubs::: :::s-šɛt'ət
+n:::š/sh:::cät̕ut:::doak:::šɛt'ut:::shet'ut:::rock::: :::šɛt'ut
+n:::š/sh:::s-cäˊmpᴇm:::doak:::s-šɛ́mpəm:::s-sh<u>e</u>mpm:::dense fog::: :::s-šɛ́mpəm
+n:::š/sh:::n-cäˊgwäl:::doak:::n-šɛ'gʷɛl:::n-she'gwel:::road::: :::n-šɛ'gʷɛl
+n:::š/sh:::uhɩs-ci'<sup>ɩ</sup>míc:::doak:::sailuhəs-šiʔmíš:::uhs-shi'm<u>i</u>sh:::my favorite::: :::uhəs-šiʔmíš
+n:::š/sh:::ciw̕t:::doak:::šiw't:::shi'wt:::rat::: :::šiw't
+n:::š/sh:::cɩciw̕t:::doak:::šəšiw't:::shshi'wt:::be daughter, girl::: :::šəšiw't
+n:::ǰ/j:::*djísu:::doak:::ǰísu:::j<u>i</u>su:::Jesus::: :::ǰísu
+n:::ǰ/j:::*djisᴐ<sup>ᴐ</sup>kri:::doak:::ǰisɔkri:::nico:::Jesus Christ::: :::ǰisɔkri
+n:::ǰ/j:::*djᴐn:::doak:::ǰɔn:::jon:::John::: :::ǰɔn
+n:::č/ch:::*tcätulí:::doak:::čɛtulí:::chetul<u>i</u>:::Catholic::: :::čɛtulí
+n:::č/ch:::tcäˊläxʷ:::doak:::čɛ́lɛxʷ:::ch<u>e</u>lekhw:::muskrat::: :::čɛ́lɛxʷ
+n:::č/ch:::s-t-tcäˊlxụm:::doak:::s-t-čɛ́lxəm:::s-t-ch<u>e</u>lkhm:::yellowhammer::: :::s-t-čɛ́lxəm
+n:::č/ch:::s-tcint:::doak:::s-čint:::s-chint:::person::: :::s-čint
+n:::č/ch:::s-t-tc-tcin̕tus:::doak:::s-t-č-čin'tus:::s-t-ch-chi'ntus:::pupil of eye::: :::s-t-č-čin'tus
+n:::č/ch:::s-tcítsu'ụmc:::doak:::s-čícuʔəmš:::s-ch<u>i</u>tsu'msh:::Coeur d'Alene::: :::s-čícuʔəmš
+n:::č/ch:::s-tcil:::doak:::s-čil:::s-chil:::game being tracked, quarry::: :::s-čil
+n:::č/ch:::t-tcɩn-ítkupᴇn:::doak:::t-čən-ítkupən:::t-chn-<u>i</u>tkupn:::Englishman (King Georgeman)::: :::t-čən-ítkupən
+n:::č/ch:::*s-tcɩntsᴐˊts:::doak:::sail:::nico:::english::: :::
+n:::č/ch:::tcɩtcäy̕ä'<sup>ä</sup>:::doak:::čəčɛy'ɛʔ:::chche'ye:::w.s. mother's mother, daughter's child::: :::čəčɛy'ɛʔ
+n:::č/ch:::tcsups:::doak:::čsups:::chsups:::tail::: :::čsups
+n:::č'/ch':::s-tc̕a'<sup>a</sup>-qín̕-cᴇn:::doak:::s-č'aɛʔ-qín'-šən':::s-ch'ae'-q<u>i</u>'n-sh'n:::knee, knuckle::: :::s-č'aɛʔ-qín'-šən'
+n:::č'/ch':::s-tc̕ä'ílup:::doak:::s-č'ɛʔílup:::s-ch'e'<u>i</u>lup:::last living relative::: :::s-č'ɛʔílup
+n:::č'/ch':::tc̕äsᴇn̕:::doak:::č'ɛsən':::ch'es'n:::louse::: :::č'ɛsən'
+n:::č'/ch':::s-tc̕äxuxʷ:::doak:::s-č'ɛxuxʷ:::s-ch'ekhukhw:::tuberculosis::: :::s-č'ɛxuxʷ
+n:::č'/ch':::tc̕äx̣-qᴇn̕:::doak:::č'ɛx-qən:::ch'ekh-qn:::helldiver::: :::č'ɛx-qən
+n:::č'/ch':::tc̕i'<sup>ɩ</sup>:::doak:::č'iʔ:::ch'i':::antler, horn::: :::č'iʔ
+n:::č'/ch':::ä<sup>ä</sup>-tc̕ímul:::doak:::ɛ-č'ímul:::e-ch'<u>i</u>mul:::pine needles::: :::ɛ-č'ímul
+n:::č'/ch':::s-tc̕im̕:::doak:::s-č'im':::s-ch'i'm:::unidentified animal::: :::s-č'im'
+n:::č'/ch':::s-t-tc̕íh-ayus:::doak:::s-t-č'íh-ayus:::s-t-ch'<u>i</u>h-ayus:::dandelion::: :::s-t-č'íh-ayus
+n:::č'/ch':::*tc̕ulai:::doak:::č'ulai:::ch'ulai:::July 4::: :::č'ulai
+n:::y, y':::yax̣-yax̣-út.cᴇn̕:::doak:::yax̣-yax̣-útšən:::yaqh-yaqh-<u>u</u>tshn:::badger::: :::yax̣-yax̣-útšən
+n:::y, y':::yuxʷmús:::doak:::yuxʷmús:::yukhwm<u>u</u>s:::Cold::: :::yuxʷmús
+n:::y, y':::yᴐˊp-yᴐp-änä'<sup>ä</sup>:::doak:::yóp-yɔp-ɛnɛʔ:::y<u>o</u>p-yop-ene':::man-eaters::: :::yóp-yɔp-ɛnɛʔ
+n:::y, y':::yɩlmíxụm:::doak:::yəlmíxəm:::ylm<u>i</u>khm:::chief::: :::yəlmíxəm
+n:::y, y':::hɩn-y̕ar̕íp:::doak:::hən-y'ar'íp:::hn-'ya'r<u>i</u>p:::rear of house::: :::hən-y'ar'íp
+n:::y, y':::y̕úkʷä'<sup>ä</sup>:::doak:::y'úkʷɛʔ:::'y<u>u</u>kwe':::w.s. younger brother::: :::y'úkʷɛʔ
+n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-gwárpᴇm:::doak:::s-gʷárpɛm:::s-gw<u>a</u>rpem:::flower::: :::s-gʷárpɛm
+n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-kum-kum-íwut.cᴇn:::doak:::s-kum-kum-íwutšən:::s-kum-kum-<u>i</u>wutsh:::rainbow::: :::s-kum-kum-íwutšən
+n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-kʷäs-kʷäs:::doak:::s-kʷɛs-kʷɛs:::s-kwes-kwes:::chicken, pheasant::: :::s-kʷɛs-kʷɛs
+n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-k̕ús-ɩstcä'<sup>ä</sup>:::doak:::s-k'us-əsčɛʔ:::s-k'us-sche':::ghost::: :::s-k'us-əsčɛʔ
+n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-t-k̕ʷáys-alqʷ:::doak:::s-t-k'ʷáy's-alqʷ:::s-t-k'w<u>a</u>'ys-alqw:::cedar tree::: :::s-t-k'ʷáy's-alqʷ
+n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::k̕ʷäpt:::doak:::k'ʷɛpt:::k'wept:::spine, backbone::: :::k'ʷɛpt
+n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-k̕u-k̕ʷäˊl̕:::doak:::s-k'u-k'ʷɛ́l':::s-k'u-k'w<u>e</u>'l:::porcupine::: :::s-k'u-k'ʷɛ́l'
+n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-k̕ʷụt̕-k̕ʷít̕-ups:::doak:::s-k'ʷət'-kʷít'-ups:::s-k'wt'-kw<u>i</u>t'-ups:::flea::: :::s-k'ʷət'-kʷít'-ups
+n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::k̕ʷít̕an  [sic]:::doak:::k'ʷít'ɛn':::k'w<u>i</u>t'e'n:::mouse::: :::k'ʷít'ɛn'
+n:::gʷ, kʷ, k'ʷ/gw, kw, k'w:::s-k̕u-k̕ʷụt-il̕t:::doak:::s-k'u-k'ʷət-il't:::s-k'u-k'wt-i'lt:::fawn::: :::s-k'u-k'ʷət-il't
+n:::xʷ/khw:::s-xú'<sup>u</sup>n-ätc:::doak:::s-xúʔn-ɛč:::s-kh<u>u</u>'n-ech:::thornberry::: :::s-xúʔn-ɛč
+n:::xʷ/khw:::s-xʷáyapaqᴇn:::doak:::s-xʷáyapaqən:::s-khw<u>a</u>yapaqn:::red willow::: :::s-xʷáyapaqən
+n:::xʷ/khw:::xʷäm-äˊtct:::doak:::xʷɛm-ɛ́čt:::khwem-<u>e</u>cht:::woodpecker::: :::xʷɛm-ɛ́čt
+n:::xʷ/khw:::xʷälä'<sup>ä</sup>:::doak:::xʷɛlɛʔ:::khwele':::meadowlark::: :::xʷɛlɛʔ
+n:::xʷ/khw:::xʷäṛʷ:::doak:::xʷɛʕʷ:::khwe(w:::bear intestines::: :::xʷɛʕʷ
+n:::xʷ/khw:::s-xʷít̕-ätcn̕:::doak:::s-xʷít'-ɛčn':::s-khw<u>i</u>t'-ech'n:::dentalium::: :::s-xʷít'-ɛčn'
+n:::xʷ/khw:::s-xʷut̕i'<sup>ɩ</sup>:::doak:::s-xʷutiʔ:::s-khwuti':::goat::: :::s-xʷutiʔ
+n:::xʷ/khw:::xʷụts̕út:::doak:::xʷəc'út:::khwts'<u>u</u>t:::Rocky Mountains::: :::xʷəc'út
+n:::xʷ/khw:::s-xʷụlíkʷ:::doak:::s-xʷəlíkʷ:::s-khwl<u>i</u>kw:::whirlwind::: :::s-xʷəlíkʷ
+n:::xʷ/khw:::s-xʷul-ᴐˊtqᴇn:::doak:::s-xʷəl-ótqən:::s-khwl-<u>o</u>tqn:::Jack Rabbit::: :::s-xʷəl-ótqən
+n:::xʷ/khw:::s-xu-xʷᴐˊm̕-qᴇn̕:::doak:::s-xu-xʷóm'-qən':::s-khu-khw<u>o</u>'m-q'n:::spoon of antler::: :::s-xu-xʷóm'-qən'
+n:::xʷ/khw:::s-xu-xʷᴐˊl-qᴇn:::doak:::s-xu-xʷól-qən':::s-khu-khw<u>o</u>l-q'n:::spearhead of antler::: :::s-xu-xʷól-qən'
+n:::q:::sɩn-qä<sup>ä</sup>m-íl̕tups:::doak:::sən-qɛm-íl'tups:::sn-qem-<u>i</u>'ltups:::dung (Coyote's powers)::: :::sən-qɛm-íl'tups
+n:::q:::qäyí'us:::doak:::qɛyíʔus:::qey<u>i</u>'us:::Cayuse::: :::qɛyíʔus
+n:::q:::qälɩspíläm:::doak:::qɛləspílɛm:::qelsp<u>i</u>lem:::Kalispelm country::: :::qɛləspílɛm
+n:::q:::qälpyä:::doak:::qɛlpyɛ:::qelpye:::black swan::: :::qɛlpyɛ
+n:::q:::s-qäl̕sí:::doak:::s-qɛl'sí:::s-qe'ls<u>i</u>:::Kutenai::: :::s-qɛl'sí
+n:::q:::qinä'<sup>ä</sup>:::doak:::qinɛʔ:::qine':::father's mother::: :::qinɛʔ
+n:::q:::qitstc:::doak:::qicč:::qitsch:::older brother::: :::qicč
+n:::q:::s-qigwts:::doak:::s-qiqʷc:::s-qiqwts:::wild potato (?) (grows in water)::: :::s-qiqʷc
+n:::q:::qíxʷɩlc:::doak:::qíxʷəlš:::q<u>i</u>khwlsh:::fish::: :::qíxʷəlš
+n:::q:::qilttc:::doak:::qiltč:::qiltch:::flesh, meat::: :::qiltč
+n:::q:::qil̕tụmxʷ:::doak:::qil'təmxʷ:::qi'ltmkhw:::man, husband::: :::qil'təmxʷ
+n:::q:::ä-qu-qul̕i'<sup>ɩ</sup>t:::doak:::ɛ-qu-qul'iʔt:::e-qu-qu'li't:::balsam fir::: :::ɛ-qu-qul'iʔt
+n:::q':::s-q̕äp-q̕ä<sup>ä</sup>p-ínä'<sup>ä</sup>:::doak:::s-q'ɛp-q'ɛp-ínɛʔ:::s-q'ep-q'ep-<u>i</u>ne':::sand::: :::s-q'ɛp-q'ɛp-ínɛʔ
+n:::q':::tcat-q̕äˊl-äy̕:::doak:::čat-q'ɛ́l-ɛy':::chat-q'<u>e</u>l-e'y:::lake (Chatcolet)::: :::čat-q'ɛ́l-ɛy'
+n:::q':::s-q̕äl-íw̕äs-cᴇn:::doak:::s-q'ɛl-íw'ɛs-šən:::s-q'el-<u>i</u>'wes-shn:::snowshoes::: :::s-q'ɛl-íw'ɛs-šən
+n:::q':::s-q̕äl̕-äps:::doak:::s-q'ɛl'-ɛps:::s-q'e'l-eps:::horse collar, necklace::: :::s-q'ɛl'-ɛps
+n:::q':::s-q̕äˊh-q̕äh:::doak:::s-q'ɛ́h-q'ɛh:::s-q'<u>e</u>h-q'eh:::small red chickenhawk::: :::s-q'ɛ́h-q'ɛh
+n:::q':::q̕ip̕xʷä'<sup>ä</sup>:::doak:::q'ip'xʷɛʔ:::q'ip'khwe':::walnut::: :::q'ip'xʷɛʔ
+n:::q':::q̕u-q̕ụm̕íw̕äs:::doak:::q'u-q'əm'íw'ɛs:::q'u-q''m<u>i</u>'wes:::colt::: :::q'u-q'əm'íw'ɛs
+n:::q':::q̕uts̕wíyä'<sup>ä</sup>:::doak:::q'uc'wíyɛʔ:::q'uts'w<u>i</u>ye':::chipmunk::: :::q'uc'wíyɛʔ
+n:::q':::q̕uyä'<sup>ä</sup>:::doak:::q'uyɛʔ:::q'uye':::name of Coyote's powers::: :::q'uyɛʔ
+n:::q':::q̕ᴐm-qᴇn:::doak:::q'ɔm-qən:::q'om-qn:::(or k'ɔmqən) head::: :::q'ɔm-qən
+n:::x̣/qh:::x̣ä'úlụmxʷ:::doak:::x̣ɛʔúləmxʷ:::qhe'<u>u</u>lmkhw:::rattlesnake::: :::x̣ɛʔúləmxʷ
+n:::x̣/qh:::x̣äˊläxʷ:::doak:::x̣ɛ́lɛxʷ:::qh<u>e</u>lekhw:::tooth::: :::x̣ɛ́lɛxʷ
+n:::x̣/qh:::x̣älíqʷä'<sup>ä</sup>:::doak:::x̣ɛlíqʷɛʔ:::qhel<u>i</u>qwe':::dried salmon roe::: :::x̣ɛlíqʷɛʔ
+n:::x̣/qh:::x̣ípä'<sup>ä</sup>:::doak:::x̣ípɛʔ:::qh<u>i</u>pe':::father's father, son's child::: :::x̣ípɛʔ
+n:::x̣/qh:::s-x̣ít̕-ụmcᴇn:::doak:::s-x̣ít'-əmšən:::s-qh<u>i</u>t'-mshn:::leggings, trousers::: :::s-x̣ít'-əmšən
+n:::x̣/qh:::s-x̣íy-ä'<sup>ä</sup>st:::doak:::s-x̣íy-ɛʔst:::s-qh<u>i</u>y-e'st:::cooking stones::: :::s-x̣íy-ɛʔst
+n:::qʷ/qw:::s-qʷán-ɬkʷä'äp:::doak:::s-qʷán-ɫkʷɛʔɛp:::s-qw<u>a</u>n-ɫkwe'ep:::empty receptacle::: :::s-qʷán-ɫkʷɛʔɛp
+n:::qʷ/qw:::s-qʷás-qʷasä'<sup>ä</sup>:::doak:::s-qʷás-qʷasɛʔ:::s-qw<u>a</u>s-qwase':::child::: :::s-qʷás-qʷasɛʔ
+n:::qʷ/qw:::s-qʷäy-u<sup>u</sup>:::doak:::s-qʷɛy-uʔ:::s-qwey-u':::grape::: :::s-qʷɛy-uʔ
+n:::qʷ/qw:::s-qʷím̕-us:::doak:::s-qʷím'-us:::s-qw<u>i</u>'m-us:::woodtick::: :::s-qʷím'-us
+n:::qʷ/qw:::s-qʷíts-ụmc:::doak:::s-qʷíc-əmš:::s-qw<u>i</u>ts-msh:::cottontail::: :::s-qʷíc-əmš
+n:::qʷ/qw:::qʷíläm̕:::doak:::qʷílɛm':::qw<u>i</u>le'm:::song::: :::qʷílɛm'
+n:::qʷ/qw:::qʷụlíwɩl̕c:::doak:::qʷəlíwəl'š:::qwl<u>i</u>w'lsh:::onion::: :::qʷəlíwəl'š
+n:::q'ʷ/q'w:::q̕ʷäsu<sup>u</sup>:::doak:::q'ʷɛsu:::q'wesu:::bunch::: :::q'ʷɛsu
+n:::q'ʷ/q'w:::s-q̕ʷäq̕ʷ-alqʷ:::doak:::s-q'ʷɛq'ʷ-alqʷ:::s-q'weq'w-alqw:::prairie grouse::: :::s-q'ʷɛq'ʷ-alqʷ
+n:::q'ʷ/q'w:::sɩn-q̕ʷụdä'úscᴇn:::doak:::sən-q'ʷədɛʔúsšən:::sn-q'wde'<u>u</u>sshn:::root::: :::sən-q'ʷədɛʔúsšən
+n:::q'ʷ/q'w:::s-t-q̕ʷụsúm̕:::doak:::s-t-q'ʷəsúm':::s-t-q'ws<u>u</u>'m:::weasel::: :::s-t-q'ʷəsúm'
+n:::q'ʷ/q'w:::q̕ʷuts̕wiyä'<sup>ä</sup>:::doak:::q'ʷuc'wiyɛʔ:::q'wuts'wiye':::chipmunk::: :::q'ʷuc'wiyɛʔ
+n:::x̣ʷ/qhw:::s-x̣u'<sup>u</sup>xʷ:::doak:::s-x̣uʔxʷ:::s-qhu'khw:::steam, vapor::: :::s-x̣uʔxʷ
+n:::x̣ʷ/qhw:::s-x̣úsᴇm:::doak:::s-x̣úsəm:::s-qh<u>u</u>sm:::soapberry::: :::s-x̣úsəm
+n:::x̣ʷ/qhw:::x̣ʷát-x̣ʷat:::doak:::x̣ʷát-x̣ʷat:::qhw<u>a</u>t-qhwat:::duck::: :::x̣ʷát-x̣ʷat
+n:::x̣ʷ/qhw:::s-x̣ʷụɬ-x̣ʷáɬ:::doak:::x̣ʷəɫ-x̣ʷáɫ:::qhwɫ-qhw<u>a</u>ɫ:::Rocky Mt. sheep::: :::x̣ʷəɫ-x̣ʷáɫ
+n:::x̣ʷ/qhw:::s-x̣ʷal-ístcᴇn:::doak:::s-x̣ʷal-ísčən:::s-qhwal-<u>i</u>schn:::buck (deer)::: :::s-x̣ʷal-ísčən
+n:::x̣ʷ/qhw:::s-x̣ʷäˊṛʷ-x̣ʷäṛʷ:::doak:::s-x̣ʷɛ́ʕʷ-x̣ʷɛʕʷ:::s-qhw<u>e</u>(w-qhwe(w:::fox::: :::s-x̣ʷɛ́ʕʷ-x̣ʷɛʕʷ
+n:::l:::*lawan:::doak:::lawan:::lawan:::oats::: :::lawan
+n:::l:::láx̣ʷ-lụxʷ  [sic]:::doak:::láx̣ʷ-ləxʷ:::l<u>a</u>qhw-lkhw:::cherry::: :::láx̣ʷ-ləxʷ
+n:::l:::s-lä<sup>ä</sup>w̕ínätc:::doak:::s-lɛw'ínɛč:::s-le'w<u>i</u>nech:::crickets::: :::s-lɛw'ínɛč
+n:::l:::*läbotäm  [sic]:::doak:::lɛbotɛm:::lebotem:::bottle::: :::lɛbotɛm
+n:::l:::*lä<sup>ä</sup>swip:::doak:::lɛswip:::leswip:::Jew::: :::lɛswip
+n:::l:::*lᴇsa<sup>a</sup>pᴐt:::doak:::ləsapɔt:::lsapot:::apostles::: :::ləsapɔt
+n:::l:::lup̕ay̕:::doak:::lup'ay':::lup'a'y:::basket::: :::lup'ay'
+n:::l:::lɩtkú:::doak:::lətkú:::ltk<u>u</u>:::otter::: :::lətkú
+n:::l:::lᴇkapí:::doak:::ləkapí:::lkap<u>i</u>:::coffee::: :::ləkapí
+n:::l:::lụqᴐsᴐˊ:::doak:::ləqɔsó:::lqos<u>o</u>:::pig::: :::ləqɔsó
+n:::ɫ, l':::hɩn-ɬámqä'<sup>ä</sup>:::doak:::hən-ɫámqɛʔ:::hn-ɫ<u>a</u>mqe':::black bear::: :::hən-ɫámqɛʔ
+n:::ɫ, l':::s-tc-ɬämt:::doak:::s-č-ɫɛmt:::s-ch-ɫemt:::light fog, dew::: :::s-č-ɫɛmt
+n:::ɫ, l':::s-tc-ɬus-mᴇn:::doak:::s-č-ɫus-mən:::s-ch-ɫus-mn:::eye::: :::s-č-ɫus-mən
+n:::ɫ, l':::s-ɬụxʷ-tct:::doak:::s-ɫəxʷ-čt:::s-ɫkhw-cht:::glove::: :::s-ɫəxʷ-čt
+n:::ɫ, l':::ɬɩtcíp:::doak:::ɫəčíp:::ɫch<u>i</u>p:::bucket::: :::ɫəčíp
+n:::ɫ, l':::l̕ᴇl̕ᴇpᴐˊt:::doak:::l'əl'əpót:::'l'lp<u>o</u>t:::cup::: :::l'əl'əpót
+n:::ɫ, l':::l̕äl̕ɩq̕ʷɩl̕c:::doak:::l'ɛl'əq'ʷəl'š:::'le'lq'w'lsh:::ripples::: :::l'ɛl'əq'ʷəl'š
+n:::ʕ, ʕʷ/(, (w:::s-ʀin:::doak:::s-ʕin:::s-(in:::catbird::: :::s-ʕin
+n:::ʕ, ʕʷ/(, (w:::s-ʀíhänt:::doak:::s-ʕíhɛnt:::s-(<u>i</u>hent:::goose::: :::s-ʕíhɛnt
+n:::ʕ, ʕʷ/(, (w:::s-ṛʷäˊl-gụl:::doak:::s-ʕʷɛ́l-gəl:::s-(w<u>e</u>l-gl:::fishnet, bagnet::: :::s-ʕʷɛ́l-gəl
+n:::h:::háy-aqs:::doak:::háy-aqs:::h<u>a</u>y-aqs:::pearl::: :::háy-aqs
+n:::h:::hamäˊɬtᴇmc:::doak:::hamɛɫtəmš:::hameɫtmsh:::fly, insect, maggot::: :::hamɛɫtəmš
+n:::h:::hɩn-hala<sup>a</sup>tsäˊ:::doak:::hən-halacɛ́:::hn-halats<u>e</u>:::(or cín) raspberry::: :::hən-halacɛ́
+n:::h:::hämä'<sup>ä</sup>:::doak:::hɛmɛʔ:::heme':::French::: :::hɛmɛʔ
 

--- a/index.js
+++ b/index.js
@@ -748,8 +748,8 @@ async function makeTables(){
 }
 
 // below call the build function(s) you want.
-
-makeTables();
+makeAffixTable();
+//makeTables();
 
 //makeAudiofileTable();
 


### PR DESCRIPTION
affixes -- note field containing only the string 'note' is now an empty string.
stems -- link field for variant forms is correct